### PR TITLE
Adicionar carteira SR à Caixa e Instruções para instalação no readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 # laravel-boleto
 Pacote para gerar boletos e remessas
 
+## Instalação
+Via composer:
+
+composer require eduardokum/laravel-boleto
+
+Ou adicione manualmente ao seu composer.json:
+
+"eduardokum/laravel-boleto": "dev-master"
+
 ## Gerar boleto
 
 Gerando somente 1
@@ -36,7 +45,7 @@ $pagador = new \Eduardokum\LaravelBoleto\Boleto\Pessoa([
 ```php
 $boletoArray = [
 	'logo' => 'path/para/o/logo', // Logo da empresa
-	'dataVencimento' => \Carbon\Carbon('1790-01-01'),
+	'dataVencimento' => new \Carbon\Carbon('1790-01-01'),
 	'valor' => 100.00,
 	'multa' => 10.00, // porcento
 	'juros' => 2.00, // porcento ao mes

--- a/src/Boleto/Banco/Caixa.php
+++ b/src/Boleto/Banco/Caixa.php
@@ -37,7 +37,7 @@ class Caixa  extends AbstractBoleto implements BoletoContract
      * Define as carteiras disponíveis para este banco
      * @var array
      */
-    protected $carteiras = ['RG'];
+    protected $carteiras = ['RG','SR'];
     /**
      * Espécie do documento, coódigo para remessa
      * @var string


### PR DESCRIPTION
Olá, parabéns pelo projeto. 

Aqui precisei adicionar a carteira SR ao banco Caixa, pois estou implementando o sistema para um cliente que ainda usa esta carteira e migrará nos próximos meses. Enfim, ainda preciso dela. E coloquei umas instruções de instalação no readme.md.

Abs.