### PR TITLE
Linha pontilhada do recibo do pagador estava cobrindo o valor

### DIFF
--- a/src/Boleto/Render/Pdf.php
+++ b/src/Boleto/Render/Pdf.php
@@ -69,6 +69,7 @@ class Pdf extends AbstractPdf implements PdfContract
         $this->Cell(0, $this->cell, $this->_(Util::nReal($this->boleto[$i]->getValor())));
         $this->SetFont($this->PadraoFont, '', $this->fcel);
 
+        $this->Ln(2);
         $this->traco('Recibo do Pagador', 4);
 
         return $this;

--- a/src/Boleto/Render/Pdf.php
+++ b/src/Boleto/Render/Pdf.php
@@ -69,7 +69,6 @@ class Pdf extends AbstractPdf implements PdfContract
         $this->Cell(0, $this->cell, $this->_(Util::nReal($this->boleto[$i]->getValor())));
         $this->SetFont($this->PadraoFont, '', $this->fcel);
 
-        $this->Ln(2);
         $this->traco('Recibo do Pagador', 4);
 
         return $this;


### PR DESCRIPTION
Antes:
![linha1](https://cloud.githubusercontent.com/assets/9788003/20922549/46a96eda-bb87-11e6-8b86-e9815154915a.PNG)

Corrigido:
![linha2](https://cloud.githubusercontent.com/assets/9788003/20922550/46c5d0ac-bb87-11e6-853d-49a951857fde.PNG)

Att.