### PR TITLE
Adicionando script para gerar a documentacao

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ before_script:
 
 script:
   - "vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover"
+
 after_script:
   - "wget https://scrutinizer-ci.com/ocular.phar"
   - "php ocular.phar code-coverage:upload --format=php-clover coverage.clover"
+
+after_success:
+  - if  [ $TRAVIS_PHP_VERSION = '5.6' ] && [ $TRAVIS_BRANCH = 'master' ]; then sh generate-api.sh; fi

--- a/generate-api.sh
+++ b/generate-api.sh
@@ -1,0 +1,23 @@
+#Shell script para ser executado pelo travis para subir a documentacao para o github pages
+#@ref: https://github.com/ApiGen/ApiGen/wiki/Generate-API-to-Github-pages-via-Travis
+#Get ApiGen.phar
+wget http://www.apigen.org/apigen.phar
+
+#Generate Api
+php apigen.phar generate -s src -d ../gh-pages --title 'Documentação laravel-boletos' --template-theme bootstrap
+
+cd ../gh-pages
+
+#Set identity
+git config --global user.email "travis@travis-ci.org"
+git config --global user.name "Travis"
+
+#Add branch
+git init
+git remote add origin https://${GH_TOKEN}@github.com/eduardokum/laravel-boleto.git > /dev/null
+git checkout -B gh-pages
+
+#Push generated files
+git add .
+git commit -m "Documentacao atualizada"
+git push origin gh-pages -fq > /dev/null


### PR DESCRIPTION
Acredito que para funcionar corretamente o .travis.yml vai precisar do token encriptado do github. Aqui explica o processo [2. Setup access for Travis](https://github.com/ApiGen/ApiGen/wiki/Generate-API-to-Github-pages-via-Travis#2-setup-access-for-travis)

Sem esse acesso o Travis não vai conseguir dar push no branch (gh_pages) onde ficará a documentação.

Fora isso, acho que é só dar permissão pra github page nos settings do repositório.

Abraços

