### PR TITLE
Alteração digito da moeda para o banco Sicredi

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Banco | Boleto | Remessa 400 | Remessa 240 | Retorno 400 | Retorno 240
  Hsbc | :white_check_mark: | :white_check_mark: | | :white_check_mark: | |
  Itau | :white_check_mark: | :white_check_mark: | | :white_check_mark: | |
  Santander | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
- Sicredi | :white_check_mark: | :white_check_mark: * | | :white_check_mark: * | |
+ Sicredi | :white_check_mark: | :white_check_mark: | | :white_check_mark: * | |
 
 **\* necessita de homologação**
 

--- a/src/Boleto/Banco/Sicredi.php
+++ b/src/Boleto/Banco/Sicredi.php
@@ -191,4 +191,17 @@ class Sicredi extends AbstractBoleto implements BoletoContract
         $campo_livre = $tipo_cobranca . $carteira . $nosso_numero . $agencia . $posto . $conta . $possui_valor . '0';
         return $this->campoLivre = $campo_livre . Util::modulo11($campo_livre);
     }
+
+    /**
+     * Retorna o código do banco com o dígito verificador ('X') para o banco Sicredi
+     *
+     * @return string
+     */
+    public function getCodigoBancoComDv()
+    {
+        $codigoBanco = $this->getCodigoBanco();
+
+        return $codigoBanco . '-' . 'X';
+    }
+
 }


### PR DESCRIPTION
Implementando metodo getCodigoBancoComDV() para alterar o dv da moeda para o caracter 'X', para atender as orientacoes do banco Sicredi. 

Removendo '*' indicando homologacao necessaria para as remessas do Banco Sicredi, já foram homologadas com sucesso.