### PR TITLE
Ajustes no boleto e remessa do SICOOB conforme homologação

### DIFF
--- a/src/Boleto/Banco/Bancoob.php
+++ b/src/Boleto/Banco/Bancoob.php
@@ -86,7 +86,8 @@ class Bancoob extends AbstractBoleto implements BoletoContract
         if (($resto != 0) && ($resto != 1)) {
             $digito_verificador = 11 - $resto;
         }
-        return $numero . $digito_verificador;
+
+        return $numero_boleto . $digito_verificador;
     }
     /**
      * Método que retorna o nosso numero usado no boleto. alguns bancos possuem algumas diferenças.

--- a/src/Cnab/Remessa/Cnab400/Banco/Bancoob.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bancoob.php
@@ -107,7 +107,7 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->add(2, 2, '1');
         $this->add(3, 9, 'REMESSA');
         $this->add(10, 11, '01');
-        $this->add(12, 26, '      COBRANÇA');
+        $this->add(12, 26, 'COBRANÇA      ');
         $this->add(27, 30, Util::formatCnab('9', $this->getAgencia(), 4));
         $this->add(31, 31, Util::modulo11($this->getAgencia()));
         $this->add(32, 40, Util::formatCnab('9', $this->getConvenio(), 9));


### PR DESCRIPTION
Correção de bug na geração do nosso número.
Na remessa estava enviando a informação "COBRANÇA" na posição errada.

Refiz a homologação com o SICOOB hoje (08/03/2017) com estes ajustes.