### PR TITLE
Inicio do unit test do BNB e Multa do Itaú

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Itau.php
@@ -230,8 +230,29 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(392, 393, Util::formatCnab('9', $boleto->getDiasProtesto($boleto->getDiasBaixaAutomatica()), 2));
         $this->add(394, 394, '');
         $this->add(395, 400, Util::formatCnab('9', $this->iRegistros + 1, 6));
+        
+        // Verifica multa
+        if ($boleto->getMulta() > 0) {
+            $this->iniciaAdicional();
+            $this->add(1, 1, Util::formatCnab('9', '2', 1)); // Adicional Multa
+            $this->add(2, 2, Util::formatCnab('X', '2', 1)); // Cód 2 = Informa Valor em percentual
+            $this->add(3, 10, $boleto->getDataVencimento()->format('dmY')); // Data da multa
+            $this->add(11, 23, Util::formatCnab('9', Util::nFloat($boleto->getMulta(), 2), 13));
+            $this->add(24, 394, '');
+            $this->add(395, 400, Util::formatCnab('9', $this->iRegistros + 1, 6));
+        }
 
         return $this;
+    }
+    
+    /**
+     * Campo adicional para a multa
+     */
+    protected function iniciaAdicional()
+    {
+        $this->iRegistros++; // Mesmo registro
+        $this->aRegistros[self::DETALHE][$this->iRegistros] = array_fill(0, 400, ' ');
+        $this->atual = &$this->aRegistros[self::DETALHE][$this->iRegistros];
     }
 
     protected function trailer()

--- a/src/Cnab/Remessa/Cnab400/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Itau.php
@@ -233,7 +233,9 @@ class Itau extends AbstractRemessa implements RemessaContract
         
         // Verifica multa
         if ($boleto->getMulta() > 0) {
-            $this->iniciaAdicional();
+            // Inicia uma nova linha de detalhe e marca com a atual de edição
+            $this->iniciaDetalhe();
+            // Campo adicional para a multa
             $this->add(1, 1, Util::formatCnab('9', '2', 1)); // Adicional Multa
             $this->add(2, 2, Util::formatCnab('X', '2', 1)); // Cód 2 = Informa Valor em percentual
             $this->add(3, 10, $boleto->getDataVencimento()->format('dmY')); // Data da multa
@@ -243,16 +245,6 @@ class Itau extends AbstractRemessa implements RemessaContract
         }
 
         return $this;
-    }
-    
-    /**
-     * Campo adicional para a multa
-     */
-    protected function iniciaAdicional()
-    {
-        $this->iRegistros++; // Mesmo registro
-        $this->aRegistros[self::DETALHE][$this->iRegistros] = array_fill(0, 400, ' ');
-        $this->atual = &$this->aRegistros[self::DETALHE][$this->iRegistros];
     }
 
     protected function trailer()

--- a/tests/Boleto/BoletoTest.php
+++ b/tests/Boleto/BoletoTest.php
@@ -418,4 +418,31 @@ class BoletoTest extends TestCase
         $this->assertNotNull($boleto->renderHTML());
         $this->assertNotNull($boleto->renderPDF());
     }
+    
+    public function testBoletoBnb()
+    {
+        $boleto = new Boleto\Bnb(
+            [
+                'logo'                   => realpath(__DIR__ . '/../../logos/') . DIRECTORY_SEPARATOR . '004.png',
+                'dataVencimento'         => new \Carbon\Carbon(),
+                'valor'                  => 100,
+                'multa'                  => 3.0,
+                'juros'                  => 1.5,
+                'numero'                 => 1,
+                'numeroDocumento'        => 1,
+                'pagador'                => self::$pagador,
+                'beneficiario'           => self::$beneficiario,
+                'carteira'               => '21',
+                'agencia'                => 1111,
+                'conta'                  => 11111,
+                'descricaoDemonstrativo' => ['demonstrativo 1', 'demonstrativo 2', 'demonstrativo 3'],
+                'instrucoes'             => ['instrucao 1', 'instrucao 2', 'instrucao 3'],
+                'aceite'                 => 'S',
+                'especieDoc'             => 'DM',
+            ]
+        );
+        $this->assertInternalType('array', $boleto->toArray());
+        $this->assertNotNull($boleto->renderHTML());
+        $this->assertNotNull($boleto->renderPDF());
+    }
 }


### PR DESCRIPTION
Essa multa do itaú é bem urgente, tinha que ter esse registro adicional pra multa, então tem gente achando que o boleto tá indo com a multa pq especificou no no campo `multa` mas na verdade não tá indo.