### PR TITLE
Retorno com ocorrência 10 no Banco do Brasil

### DIFF
--- a/src/Cnab/Retorno/Cnab400/Banco/Bb.php
+++ b/src/Cnab/Retorno/Cnab400/Banco/Bb.php
@@ -217,7 +217,7 @@ class Bb extends AbstractRetorno implements RetornoCnab400
         } elseif ($d->hasOcorrencia('02')) {
             $this->totais['entradas']++;
             $d->setOcorrenciaTipo($d::OCORRENCIA_ENTRADA);
-        } elseif ($d->hasOcorrencia('09')) {
+        } elseif ($d->hasOcorrencia('09', '10')) {
             $this->totais['baixados']++;
             $d->setOcorrenciaTipo($d::OCORRENCIA_BAIXADA);
         } elseif ($d->hasOcorrencia('61')) {


### PR DESCRIPTION
O retorno com ocorrência 10 no BB significa: Baixa Solicitada Pelo Beneficiário. Considerar como transação baixada também como o 09.