### PR TITLE
Update Util.php - Codificação UTF-8 para arquivos de retorno SICOOB

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -831,7 +831,7 @@ final class Util
     public static function isCnab240($content)
     {
         $content = is_array($content) ? $content[0] : $content;
-        return mb_strlen(rtrim($content, "\r\n")) == 240 ? true : false;
+        return mb_strlen(rtrim(utf8_decode($content), "\r\n")) == 240 ? true : false;
     }
 
     /**
@@ -843,7 +843,7 @@ final class Util
     public static function isCnab400($content)
     {
         $content = is_array($content) ? $content[0] : $content;
-        return mb_strlen(rtrim($content, "\r\n")) == 400 ? true : false;
+        return mb_strlen(rtrim(utf8_decode($content), "\r\n")) == 400 ? true : false;
     }
 
     /**


### PR DESCRIPTION
Na validação para o tipo de cnab 400 e cnab 240, estou passando o conteúdo para UTF-8,  ja que o conteúdo que vem nos arquivos de retorno SICOOB está em ANSI, pois para o obter o número de caracteres usando "mb_strlen" a sequencia dos caracteres devem ser UTF8.