### PR TITLE
Alteração quantidade de caracter CEI

### DIFF
--- a/src/Pessoa.php
+++ b/src/Pessoa.php
@@ -116,7 +116,7 @@ class Pessoa implements PessoaContract
     public function setDocumento($documento)
     {
         $documento = substr(Util::onlyNumbers($documento), -14);
-        if (!in_array(strlen($documento), [10, 11, 14, 0])) {
+        if (!in_array(strlen($documento), [12, 11, 14, 0])) {
             throw new \Exception('Documento inválido');
         }
         $this->documento = $documento;
@@ -131,7 +131,7 @@ class Pessoa implements PessoaContract
         if ($this->getTipoDocumento() == 'CPF') {
             return Util::maskString(Util::onlyNumbers($this->documento), '###.###.###-##');
         } elseif ($this->getTipoDocumento() == 'CEI') {
-            return Util::maskString(Util::onlyNumbers($this->documento), '##.#####.#-##');
+            return Util::maskString(Util::onlyNumbers($this->documento), '###.###.####/##');
         }
         return Util::maskString(Util::onlyNumbers($this->documento), '##.###.###/####-##');
     }

--- a/tests/PessoaTest.php
+++ b/tests/PessoaTest.php
@@ -55,9 +55,9 @@ class PessoaTest extends TestCase
         $this->assertEquals(Util::maskString($documento, '##.###.###/####-##'), $pessoa->getDocumento());
         $this->assertEquals('CNPJ', $pessoa->getTipoDocumento());
 
-        $documento = '9999999999';
+        $documento = '999999999999';
         $pessoa->setDocumento($documento);
-        $this->assertEquals(Util::maskString($documento, '##.#####.#-##'), $pessoa->getDocumento());
+        $this->assertEquals(Util::maskString($documento, '###.###.####/##'), $pessoa->getDocumento());
         $this->assertEquals('CEI', $pessoa->getTipoDocumento());
 
     }
@@ -137,12 +137,12 @@ class PessoaTest extends TestCase
         $this->assertEquals('CPF', $pessoa->getTipoDocumento());
         $this->assertEquals('999.999.999-99', $pessoa->getDocumento());
 
-        $pessoa->setDocumento('99.99999.9-99');
+        $pessoa->setDocumento('999.999.9999-99');
         $this->assertEquals('CEI', $pessoa->getTipoDocumento());
-        $this->assertEquals('99.99999.9-99', $pessoa->getDocumento());
-        $pessoa->setDocumento('9999999999');
+        $this->assertEquals('999.999.9999-99', $pessoa->getDocumento());
+        $pessoa->setDocumento('999999999999');
         $this->assertEquals('CEI', $pessoa->getTipoDocumento());
-        $this->assertEquals('99.99999.9-99', $pessoa->getDocumento());
+        $this->assertEquals('999.999.9999-99', $pessoa->getDocumento());
 
     }
 }


### PR DESCRIPTION
Alterado a quantidade de caracteres do documento CEI de 10 para 12 e formatado a mascara do mesmo.