### PR TITLE
Ajustes remessa 400

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Santander.php
@@ -102,14 +102,16 @@ class Santander extends AbstractRemessa implements RemessaContract
     /**
      * Retorna o codigo de transmissão.
      *
+     * @param int $shiftConta
+     * @param int $tamanhoConta
+     *
      * @return string
-     * @throws \Exception
      */
-    public function getCodigoTransmissao()
+    public function getCodigoTransmissao($shiftConta = 1, $tamanhoConta = 8)
     {
         return Util::formatCnab('9', $this->getAgencia(), 4)
             . Util::formatCnab('9', $this->getCodigoCliente(), 8)
-            . Util::formatContaCnab($this->getConta(), 8);
+            . Util::formatContaCnab($this->getConta(), $shiftConta, $tamanhoConta);
     }
 
     /**

--- a/src/Cnab/Remessa/Cnab400/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Santander.php
@@ -109,7 +109,7 @@ class Santander extends AbstractRemessa implements RemessaContract
     {
         return Util::formatCnab('9', $this->getAgencia(), 4)
             . Util::formatCnab('9', $this->getCodigoCliente(), 8)
-            . Util::formatCnab('9', $this->getConta(), 8);
+            . Util::formatContaCnab($this->getConta(), 8);
     }
 
     /**

--- a/src/Util.php
+++ b/src/Util.php
@@ -493,6 +493,19 @@ final class Util
     }
 
     /**
+     * @param        $valor
+     * @param int $tamanho
+     * @param string $sFill
+     *
+     * @return string
+     */
+    public static function formatContaCnab($valor, $tamanho = 8, $sFill = '0')
+    {
+        $valor = self::onlyNumbers($valor);
+        return sprintf("%{$sFill}{$tamanho}s", mb_substr($valor, 0, $tamanho - 1));
+    }
+
+    /**
      * @param        Carbon|string $date
      * @param string $format
      *

--- a/src/Util.php
+++ b/src/Util.php
@@ -494,15 +494,15 @@ final class Util
 
     /**
      * @param        $valor
+     * @param int $shift
      * @param int $tamanho
      * @param string $sFill
      *
      * @return string
      */
-    public static function formatContaCnab($valor, $tamanho = 8, $sFill = '0')
+    public static function formatContaCnab($valor, $shift = 1, $tamanho = 8, $sFill = '0')
     {
-        $valor = self::onlyNumbers($valor);
-        return sprintf("%{$sFill}{$tamanho}s", mb_substr($valor, 0, $tamanho - 1));
+        return sprintf("%{$sFill}{$tamanho}s", mb_substr($valor, 0, $tamanho - $shift));
     }
 
     /**


### PR DESCRIPTION
Alguns ajustes me foram solicitados numa última tentativa de homologação. Estes ajustes iam na direção de aplicar um "deslocamento" de uma casa à direita no campo referente a conta dos headers.

Após essa alteração, **consegui a homologação concluída**.

Se houver alguma solução melhor, podemos discutir aqui. A conta que estou utilizando possui 9 dígitos.