### PR TITLE
MELHORIA NAS REGRAS DO DUPLO DIGITO BANRISUL

### DIFF
--- a/src/CalculoDV.php
+++ b/src/CalculoDV.php
@@ -156,19 +156,23 @@ class CalculoDV
 
     public static function banrisulDuploDigito($campo)
     {
-         $dv1 = Util::modulo10($campo);
-            if ($dv1==9) {
+        $dv1 = Util::modulo10($campo);
+        if ($dv1 > 9) {
+            $dv1 = 0;
+        }
+
+        $dv2 = Util::modulo11($campo . $dv1, 2, 7, 0, 10);
+        if ($dv2 == 10) {
+            $dv1++;
+        }
+        if ($dv2 == 1) {
+            if ($dv1 == 9){
                 $dv1 = 0;
             }
-            $dv2 = Util::modulo11($campo . $dv1, 2, 7, 0, 10);
-            if ($dv2 == 10 || $dv2 == 1) {
-                $dv1++;
-                $dv2 = Util::modulo11($campo . $dv1, 2, 7, 0, 10);
-                if ($dv1 > 9) {
-                    $dv1 = 0;
-                }
-            }
-            return $dv1 . $dv2;
+        }
+
+        $dv2 = Util::modulo11($campo . $dv1, 2, 7, 0, 10);
+        return $dv1 . $dv2;
     }
 
     /*


### PR DESCRIPTION
Notas:
 -> Caso o somatório obtido seja menor que 11, considerar como resto da divisão o próprio somatório.
 -> Caso o resto obtido no cálculo do módulo 11 seja igual a 1, considera-se o DV inválido.
 -> Soma-se, então, 1 ao DV obtido do módulo 10 e refaz-se o cálculo do módulo 11.
 -> Se o dígito obtido pelo módulo 10 era igual a 9, considera-se então (9+1=10) DV inválido.
 -> Neste caso, o DV do módulo 10 automaticamente será igual a 0 e procede-se assim novo cálculo pelo módulo 11.
 -> Caso o resto obtido no cálculo do módulo 11 seja 0, o segundo NC será igual ao próprio resto.