### PR TITLE
adição de data de criação da remessa (sicredi)

### DIFF
--- a/src/Cnab/Remessa/AbstractRemessa.php
+++ b/src/Cnab/Remessa/AbstractRemessa.php
@@ -86,6 +86,12 @@ abstract class AbstractRemessa
      */
     protected $idremessa;
     /**
+     * A data que será informada no header da remessa
+     *
+     * @var \Carbon\Carbon;
+     */
+    protected $dataRemessa = null;
+    /**
      * Agência
      *
      * @var int
@@ -133,6 +139,25 @@ abstract class AbstractRemessa
         Util::fillClass($this, $params);
     }
 
+ /**
+     * Informa a data da remessa a ser gerada
+     *
+     */
+    public function setDataRemessa($data){
+        $this->dataRemessa = $data;
+    }
+
+    /**
+     * Retorna a data da remessa a ser gerada
+     *
+     * @return \Carbon\Carbon;
+     */
+    public function getDataRemessa($format){
+        if(is_null($this->dataRemessa)){
+            return \Carbon\Carbon::now()->format($format);
+        }
+        return $this->dataRemessa->format($format);
+    }
     /**
      * Seta os campos obrigatórios
      *

--- a/src/Cnab/Remessa/Cnab240/Banco/Bancoob.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bancoob.php
@@ -311,7 +311,7 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->add(74, 103, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(104, 183, '');
         $this->add(184, 191, Util::formatCnab('9', $this->getIdremessa(), 8));
-        $this->add(192, 199, date('dmY'));
+        $this->add(192, 199, $this->getDataRemessa('dmY'));
         $this->add(200, 207, '00000000');
         $this->add(208, 240, '');
 

--- a/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
@@ -276,7 +276,7 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(103, 132, Util::formatCnab('X', 'BANRISUL', 30));
         $this->add(133, 142, '');
         $this->add(143, 143, 1);
-        $this->add(144, 151, date('dmY'));
+        $this->add(144, 151, $this->getDataRemessa('dmY'));
         $this->add(152, 157, date('His'));
         $this->add(158, 163, '000000');
         $this->add(164, 166, '040');

--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -298,7 +298,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(103, 132, Util::formatCnab('X', 'BANCO DO BRASIL S.A.', 30));
         $this->add(133, 142, '');
         $this->add(143, 143, 1);
-        $this->add(144, 151, date('dmY'));
+        $this->add(144, 151, $this->getDataRemessa('dmY'));
         $this->add(152, 157, date('His'));
         $this->add(158, 163, '000000');
         $this->add(164, 166, '084');

--- a/src/Cnab/Remessa/Cnab240/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bradesco.php
@@ -315,7 +315,7 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(103, 132, Util::formatCnab('X', 'Bradesco', 30));
         $this->add(133, 142, '');
         $this->add(143, 143, 1);
-        $this->add(144, 151, date('dmY'));
+        $this->add(144, 151, $this->getDataRemessa('dmY'));
         $this->add(152, 157, date('His'));
         $this->add(158, 163, Util::formatCnab('9', $this->getIdremessa(), 6));
         $this->add(164, 166, '084');

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -253,7 +253,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(103, 132, Util::formatCnab('X', 'CAIXA ECONOMICA FEDERAL', 30));
         $this->add(133, 142, '');
         $this->add(143, 143, 1);
-        $this->add(144, 151, date('dmY'));
+        $this->add(144, 151, $this->getDataRemessa('dmY'));
         $this->add(152, 157, date('His'));
         $this->add(158, 163, Util::formatCnab('9', $this->getIdremessa(), 6));
         $this->add(164, 166, '101');

--- a/src/Cnab/Remessa/Cnab240/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Itau.php
@@ -250,7 +250,7 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(103, 132, Util::formatCnab('X', 'BANCO ITAU SA', 30));
         $this->add(133, 142, '');
         $this->add(143, 143, 1);
-        $this->add(144, 151, date('dmY'));
+        $this->add(144, 151, $this->getDataRemessa('dmY'));
         $this->add(152, 157, date('His'));
         $this->add(158, 163, '000000');
         $this->add(164, 166, '040');

--- a/src/Cnab/Remessa/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Santander.php
@@ -200,7 +200,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(103, 132, Util::formatCnab('X', 'Banco Santander', 30));
         $this->add(133, 142, '');
         $this->add(143, 143, '1');
-        $this->add(144, 151, date('dmY'));
+        $this->add(144, 151, $this->getDataRemessa('dmY'));
         $this->add(152, 157, '');
         $this->add(158, 163, Util::formatCnab('9', 0, 6));
         $this->add(164, 166, Util::formatCnab('9', '040', 3));

--- a/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
@@ -281,7 +281,7 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(103, 132, Util::formatCnab('X', 'SICREDI', 30));
         $this->add(133, 142, '');
         $this->add(143, 143, 1);
-        $this->add(144, 151, date('dmY'));
+        $this->add(144, 151, $this->getDataRemessa('dmY'));
         $this->add(152, 157, date('His'));
         $this->add(158, 163, Util::formatCnab('9', $this->getIdremessa(), 6));
         $this->add(164, 166, '081');

--- a/src/Cnab/Remessa/Cnab400/Banco/Bancoob.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bancoob.php
@@ -116,7 +116,7 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->add(47, 76, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'BANCOOBCED', 15));
-        $this->add(95, 100, date('dmy'));
+        $this->add(95, 100, $this->getDataRemessa('dmy'));
         $this->add(101, 107, Util::formatCnab('9', $this->getIdremessa(), 7));
         $this->add(108, 394, '');
         $this->add(395, 400, Util::formatCnab('9', 1, 6));

--- a/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
@@ -219,7 +219,7 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 87, Util::formatCnab('X', 'BANRISUL', 8));
         $this->add(88, 94, '');
-        $this->add(95, 100, date('dmy'));
+        $this->add(95, 100, $this->getDataRemessa('dmy'));
         $this->add(101, 109, '');
         $this->add(110, 113, Util::formatCnab('9', $cod_servico, 4));
         $this->add(114, 114, '');

--- a/src/Cnab/Remessa/Cnab400/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bb.php
@@ -207,7 +207,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(47, 76, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'BANCODOBRASIL', 15));
-        $this->add(95, 100, date('dmy'));
+        $this->add(95, 100, $this->getDataRemessa('dmy'));
         $this->add(101, 107, Util::formatCnab('9', $this->getIdremessa(), 7));
         $this->add(108, 129, '');
         $this->add(130, 136, Util::formatCnab('9', $this->getConvenioLider(), 7));

--- a/src/Cnab/Remessa/Cnab400/Banco/Bnb.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bnb.php
@@ -63,7 +63,7 @@ class Bnb extends AbstractRemessa implements RemessaContract
      * @var null
      */
     protected $fimArquivo = "\r\n";
-    
+
     /**
      * Retorna o numero da carteira, deve ser override em casos de carteira de letras
      *
@@ -76,7 +76,7 @@ class Bnb extends AbstractRemessa implements RemessaContract
         }
         return '1';
     }
-    
+
     protected function header()
     {
         $this->iniciaHeader();
@@ -94,7 +94,7 @@ class Bnb extends AbstractRemessa implements RemessaContract
         $this->add(47, 76, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'B.DO NORDESTE', 15));
-        $this->add(95, 100, date('dmy'));
+        $this->add(95, 100, $this->getDataRemessa('dmy'));
         $this->add(101, 394, '');
         $this->add(395, 400, Util::formatCnab('9', 1, 6));
 

--- a/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
@@ -143,7 +143,7 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(47, 76, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'Bradesco', 15));
-        $this->add(95, 100, date('dmy'));
+        $this->add(95, 100, $this->getDataRemessa('dmy'));
         $this->add(101, 108, '');
         $this->add(109, 110, 'MX');
         $this->add(111, 117, Util::formatCnab('9', $this->getIdremessa(), 7));

--- a/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
@@ -130,7 +130,7 @@ class Caixa  extends AbstractRemessa implements RemessaContract
         $this->add(47, 76, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'C ECON FEDERAL', 15));
-        $this->add(95, 100, date('dmy'));
+        $this->add(95, 100, $this->getDataRemessa('dmy'));
         $this->add(101, 389, '');
         $this->add(390, 394, Util::formatCnab('9', $this->getIdremessa(), 5));
         $this->add(395, 400, Util::formatCnab('9', 1, 6));

--- a/src/Cnab/Remessa/Cnab400/Banco/Hsbc.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Hsbc.php
@@ -126,7 +126,7 @@ class Hsbc extends AbstractRemessa implements RemessaContract
         $this->add(47, 76, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'HSBC', 15));
-        $this->add(95, 100, date('dmy'));
+        $this->add(95, 100, $this->getDataRemessa('dmy'));
         $this->add(101, 105, '01600');
         $this->add(106, 108, 'BPI');
         $this->add(109, 110, '');

--- a/src/Cnab/Remessa/Cnab400/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Itau.php
@@ -156,7 +156,7 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(47, 76, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'BANCO ITAU SA', 15));
-        $this->add(95, 100, date('dmy'));
+        $this->add(95, 100, $this->getDataRemessa('dmy'));
         $this->add(101, 394, '');
         $this->add(395, 400, Util::formatCnab('9', 1, 6));
 
@@ -231,7 +231,7 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(392, 393, Util::formatCnab('9', $boleto->getDiasProtesto($boleto->getDiasBaixaAutomatica()), 2));
         $this->add(394, 394, '');
         $this->add(395, 400, Util::formatCnab('9', $this->iRegistros + 1, 6));
-        
+
         // Verifica multa
         if ($boleto->getMulta() > 0) {
             // Inicia uma nova linha de detalhe e marca com a atual de edição

--- a/src/Cnab/Remessa/Cnab400/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Santander.php
@@ -138,7 +138,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(47, 76, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'SANTANDER', 15));
-        $this->add(95, 100, date('dmy'));
+        $this->add(95, 100, $this->getDataRemessa('dmy'));
         $this->add(101, 116, Util::formatCnab('9', '0', 16));
         $this->add(117, 391, '');
         $this->add(392, 394, '000');
@@ -209,7 +209,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(352, 381, Util::formatCnab('X', $boleto->getSacadorAvalista() ? $boleto->getSacadorAvalista()->getNome() : '', 30));
         $this->add(382, 382, '');
         $this->add(383, 383, 'I');
-        $this->add(384, 385, substr($this->getConta(), -1) . CalculoDV::santanderContaCorrente($this->getAgencia(), $this->getConta()));        
+        $this->add(384, 385, substr($this->getConta(), -1) . CalculoDV::santanderContaCorrente($this->getAgencia(), $this->getConta()));
         if (strlen($this->getConta()) == 9) {
             $this->add(384, 385, substr($this->getConta(), -2));
         }

--- a/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
@@ -96,7 +96,7 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(46, 76, '');
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'Sicredi', 15));
-        $this->add(95, 102, date('Ymd'));
+        $this->add(95, 102, $this->getDataRemessa('Ymd'));
         $this->add(103, 110, '');
         $this->add(111, 117, Util::formatCnab('9', $this->getIdremessa(), 7));
         $this->add(118, 390, '');


### PR DESCRIPTION
Possibilidade de passar a data de geração da remessa, para seja possível refazer uma remessa alterando a data.

Exemplo:

Caso a data não seja passada, continua a data atual 

Ex criação da remessa:

```
            'variacaoCarteira' => $contaBancaria->variacao_carteira,
            'beneficiario' => $this->geraBeneficiario($contaBancaria),
            'dataRemessa' => Carbon::now() //ex
   ];
```