### PR TITLE
Remessa Bradesco Cnab400 divergente da documentação do Banco

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
@@ -170,9 +170,13 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(8, 12, '');
         $this->add(13, 19, '');
         $this->add(20, 20, '');
-        $this->add(21, 37, Util::formatCnab('9', $this->getCodigoCliente(), 17));
+        $this->add(21, 21, '0');
+        $this->add(22, 24, Util::formatCnab('9', $this->getCarteira(), 3));
+        $this->add(25, 29, Util::formatCnab('9', $this->getAgencia(), 5));
+        $this->add(30, 36, Util::formatCnab('9', $this->getConta(), 7));
+        $this->add(37, 37, Util::formatCnab('9', $this->getContaDv(), 1));
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle
-        $this->add(63, 65, $this->getCodigoBanco());
+        $this->add(63, 65, '000');
         $this->add(66, 66, $boleto->getMulta() > 0 ? '2' : '0');
         $this->add(67, 70, Util::formatCnab('9', $boleto->getMulta() > 0 ? $boleto->getMulta() : '0', 4, 2));
         $this->add(71, 82, Util::formatCnab('9', $boleto->getNossoNumero(), 12));


### PR DESCRIPTION
* Aplicado as informações de conta corretamente de acordo com o manual do Bradesco