### PR TITLE
Quantidade de registros no trailerlote e trailer remessa BB

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -362,7 +362,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0001');
         $this->add(8, 8, '5');
         $this->add(9, 17, '');
-        $this->add(18, 23, Util::formatCnab('9', count($this->boletos) + 2, 6));
+        $this->add(18, 23, Util::formatCnab('9', count($this->boletos) * 2 + 2, 6));
         $this->add(24, 240, '');
 
         return $this;
@@ -381,7 +381,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(8, 8, '9');
         $this->add(9, 17, '');
         $this->add(18, 23, Util::formatCnab('9', 1, 6));
-        $this->add(24, 29, Util::formatCnab('9', count($this->aRegistros) + 1, 6));
+        $this->add(24, 29, Util::formatCnab('9', $this->getCount() + 2, 6));
         $this->add(30, 35, '000001');
         $this->add(36, 240, '');
 


### PR DESCRIPTION
Ao validar o leiaute no site do BB verifiquei que ele não soma todas as linhas corretamente, em trailerlote ele soma apenas os segmentos P, mas para cada boleto deveria ser 2 linhas, por isso coloquei * 2.

No trailer eu coloquei a função que está no AbstractRemessa getCount(), pois ele soma certo as linhas da remessa.