### PR TITLE
Correcao da leitura do nosso numero no retorno do CNAB240 do Bancoob e do código do desconto da remessa CNAB240 BB.

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -199,7 +199,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(118, 118, $boleto->getJuros() ? '1' : '3'); //'1' = Valor por Dia, '3' = Isento
         $this->add(119, 126, $boleto->getDataVencimento()->format('dmY'));
         $this->add(127, 141, Util::formatCnab('9', $boleto->getMoraDia(), 15, 2)); //Valor da mora/dia ou Taxa mensal
-        $this->add(142, 142, '1'); // '1' = Valor Fixo Até a Data Informada
+        $this->add(142, 142, $boleto->getDesconto() > 0 ? '1' : '0'); // Se houver desconto '1' = Valor Fixo Até a Data Informada, Se não houver envia o 0
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');
         $this->add(151, 165, Util::formatCnab('9', $boleto->getDesconto(), 15, 2));
         $this->add(166, 180, Util::formatCnab('9', 0, 15, 2));

--- a/src/Cnab/Retorno/Cnab240/Banco/Bancoob.php
+++ b/src/Cnab/Retorno/Cnab240/Banco/Bancoob.php
@@ -282,7 +282,7 @@ class Bancoob extends AbstractRetorno implements RetornoCnab240
         if ($this->getSegmentType($detalhe) == 'T') {
             $d->setOcorrencia($this->rem(16, 17, $detalhe))
                 ->setOcorrenciaDescricao(array_get($this->ocorrencias, $this->detalheAtual()->getOcorrencia(), 'Desconhecida'))
-                ->setNossoNumero($this->rem(38, 57, $detalhe))
+                ->setNossoNumero($this->rem(38, 47, $detalhe))
                 ->setCarteira($this->rem(58, 58, $detalhe))
                 ->setNumeroDocumento($this->rem(59, 73, $detalhe))
                 ->setDataVencimento($this->rem(74, 81, $detalhe))


### PR DESCRIPTION
- O processamento do retorno do CNAB240 do Bancoob estava retornando o número da parcela, a modalidade e o tipo do formulário juntamente com o nosso número. O limite de posições foi corrigido para 38 a 47, porque o nosso número ocupa apenas as 10 primeiras posições após a coluna 38 do registro de detalhe do segmento T nesse retorno.
- O código do desconto da remessa do CNAB240 do BB deve ir com valor 0 caso não ocorram descontos.