### PR TITLE
Remessa CNAB240 BB .: correção do campo número do documento

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -188,7 +188,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(60, 60, '');
         $this->add(61, 61, '');
         $this->add(62, 62, '');
-        $this->add(63, 77, Util::formatCnab('9', $boleto->getNumero(), 15));
+        $this->add(63, 77, Util::formatCnab('9', $boleto->getNumeroDocumento(), 15)); //valor do número do documento
         $this->add(78, 85, $boleto->getDataVencimento()->format('dmY'));
         $this->add(86, 100, Util::formatCnab('9', $boleto->getValor(), 15, 2));
         $this->add(101, 105, '00000');


### PR DESCRIPTION
O valor que estava sendo enviado na remessa nesse campo (coluna 63 a 77 do segmento P) era o número do boleto e não o número do documento como consta na documentação: 
![camponumerodoc](https://user-images.githubusercontent.com/15219598/43467841-0b887b04-94b9-11e8-8ea4-7abea34d6bc1.png)
