### PR TITLE
Correção Agência / Código Beneficiário CEF

### DIFF
--- a/src/Boleto/Banco/Caixa.php
+++ b/src/Boleto/Banco/Caixa.php
@@ -108,6 +108,16 @@ class Caixa  extends AbstractBoleto implements BoletoContract
     }
 
     /**
+     * Na CEF deve retornar agência (sem o DV) / código beneficiário (com DV)
+     * @return [type] [description]
+     */
+    public function getAgenciaCodigoBeneficiario(){
+        return $this->getAgencia() . ' / ' . 
+               $this->getCodigoCliente() . '-' . 
+               Util::modulo11($this->getCodigoCliente());
+    }
+
+    /**
      * Seta dias para baixa automática
      *
      * @param int $baixaAutomatica

--- a/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
@@ -220,7 +220,7 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(134, 136, Util::formatCnab('9', Util::onlyNumbers(substr($boleto->getPagador()->getCep(), 6, 9)), 3));
         $this->add(137, 151, Util::formatCnab('X', $boleto->getPagador()->getCidade(), 15));
         $this->add(152, 153, Util::formatCnab('X', $boleto->getPagador()->getUf(), 2));
-        $this->add(154, 154, '1');
+        $this->add(154, 154, '0');
         $this->add(155, 169, '000000000000000');
         $this->add(170, 209, '');
         $this->add(210, 212, '000');

--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -257,7 +257,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(134, 136, Util::formatCnab('9', Util::onlyNumbers(substr($boleto->getPagador()->getCep(), 6, 9)), 3));
         $this->add(137, 151, Util::formatCnab('X', $boleto->getPagador()->getCidade(), 15));
         $this->add(152, 153, Util::formatCnab('X', $boleto->getPagador()->getUf(), 2));
-        $this->add(154, 154, '1');
+        $this->add(154, 154, '0');
         $this->add(155, 169, '000000000000000');
         $this->add(170, 209, '');
         $this->add(210, 212, '000');

--- a/src/Cnab/Remessa/Cnab240/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bradesco.php
@@ -245,7 +245,7 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(134, 136, Util::formatCnab('9', Util::onlyNumbers(substr($boleto->getPagador()->getCep(), 6, 9)), 3));
         $this->add(137, 151, Util::formatCnab('X', $boleto->getPagador()->getCidade(), 15));
         $this->add(152, 153, Util::formatCnab('X', $boleto->getPagador()->getUf(), 2));
-        $this->add(154, 154, '1');
+        $this->add(154, 154, '0');
         $this->add(155, 169, '000000000000000');
         $this->add(170, 209, '');
         $this->add(210, 212, '000');

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -44,7 +44,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
     const OCORRENCIA_ALT_VALOR = '47';
     const OCORRENCIA_ALT_VALOR_MIN_MAX = '48';
 
-    const PROTESTO_SEM = '0';
+    const PROTESTO_SEM = '3';
     const PROTESTO_DIAS_UTEIS = '1';
     const PROTESTO_NAO_PROTESTAR = '3';
     const PROTESTO_AUTOMATICO = '9';
@@ -172,7 +172,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
             $this->add(221, 221, self::PROTESTO_DIAS_UTEIS);
         }
         $this->add(222, 223, Util::formatCnab('9', $boleto->getDiasProtesto(), 2));
-        $this->add(224, 224, '2'); // '2' = Não Baixar / Não Devolver (NÃO TRATADO PELO BANCO)
+        $this->add(224, 224, '1'); // '1' = Baixar/Devolver / 2' = Não Baixar / Não Devolver (NÃO TRATADO PELO BANCO)
         $this->add(225, 227, Util::formatCnab('9', $boleto->getDiasBaixaAutomatica(), 3));  //Se informado 000 será baixado no dia posterior do vencimento. Se for informado '' será baixado 5 dias após o vencimento, se não será baixado os dias informados
         $this->add(228, 229, Util::formatCnab('9', $boleto->getMoeda(), 2));
         $this->add(230, 239, '0000000000');

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -145,11 +145,11 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(38, 39, '00');
         $this->add(40, 57, Util::formatCnab('9', $boleto->getNossoNumero(), 17));
         $this->add(58, 58, '1'); //'1' = Cobrança Simples
-        $this->add(59, 59, '1'); // ‘1’ - Cobrança Registrada
+        $this->add(59, 59, '1'); //'1' - Cobrança Registrada
         $this->add(60, 60, '2'); //'2’ - Escritural
         $this->add(61, 61, '2'); //‘2’ = Cliente Emite
         $this->add(62, 62, '0'); //‘0’ = Postagem pelo Beneficiário
-        $this->add(63, 73, Util::formatCnab('9', $boleto->getNumeroDocumento(), 11));
+        $this->add(63, 73, Util::formatCnab('X', $boleto->getNumeroDocumento(), 11));
         $this->add(74, 77, '');
         $this->add(78, 85, $boleto->getDataVencimento()->format('dmY'));
         $this->add(86, 100, Util::formatCnab('9', $boleto->getValor(), 15, 2));
@@ -158,9 +158,9 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(107, 108, Util::formatCnab('9', $boleto->getEspecieDocCodigo(), 2));
         $this->add(109, 109, Util::formatCnab('9', $boleto->getAceite(), 1));
         $this->add(110, 117, $boleto->getDataDocumento()->format('dmY'));
-        $this->add(118, 118, $boleto->getJuros() ? '1' : '3'); //'1' = Valor por Dia, '3' = Isento
+        $this->add(118, 118, $boleto->getJuros() ? '2' : '3'); //'2' = Percentual Mensal '3' = Isento
         $this->add(119, 126, $boleto->getDataVencimento()->format('dmY'));
-        $this->add(127, 141, Util::formatCnab('9', $boleto->getMoraDia(), 15, 2)); //Valor da mora/dia ou Taxa mensal
+        $this->add(127, 141, Util::formatCnab('9', $boleto->getJuros(), 15, 2)); //Taxa mensal
         $this->add(142, 142, $boleto->getDesconto() > 0 ? '1' : '0'); // 0 = Sem Desconto, 1 = Valor Fixo até a data informada, 2 = Percentual até a data informada
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');
         $this->add(151, 165, Util::formatCnab('9', $boleto->getDesconto(), 15, 2));

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -68,7 +68,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
      *
      * @var array
      */
-    protected $carteiras = ['RG'];
+    protected $carteiras = ['RG', 'SR'];
 
     /**
      * Codigo do cliente junto ao banco.

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -302,7 +302,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(164, 166, '101');
         $this->add(167, 171, '00000');
         $this->add(172, 191, '');
-        $this->add(192, 211, '');
+        $this->add(192, 211, 'REMESSA-PRODUCAO');
         $this->add(212, 215, '');
         $this->add(216, 240, '');
         return $this;

--- a/src/Cnab/Remessa/Cnab240/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Itau.php
@@ -175,7 +175,7 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(134, 136, Util::formatCnab('9', Util::onlyNumbers(substr($boleto->getPagador()->getCep(), 6, 9)), 3));
         $this->add(137, 151, Util::formatCnab('X', $boleto->getPagador()->getCidade(), 15));
         $this->add(152, 153, Util::formatCnab('X', $boleto->getPagador()->getUf(), 2));
-        $this->add(154, 154, '1');
+        $this->add(154, 154, '0');
         $this->add(155, 169, '000000000000000');
         $this->add(170, 199, '');
         $this->add(200, 209, '');

--- a/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
@@ -51,7 +51,7 @@ class Caixa  extends AbstractRemessa implements RemessaContract
      *
      * @var array
      */
-    protected $carteiras = ['RG'];
+    protected $carteiras = ['RG', 'SR'];
 
     /**
      * Caracter de fim de linha


### PR DESCRIPTION
Correção onde calcula o atributo agencia_codigo_beneficiario errado, quando o banco utilizado era CEF.