### PR TITLE
Label errada no Boleto

### DIFF
--- a/src/Boleto/Render/Pdf.php
+++ b/src/Boleto/Render/Pdf.php
@@ -315,7 +315,7 @@ class Pdf extends AbstractPdf implements PdfContract
         $this->Cell(50, $this->cell, $this->_(''), 'R', 1);
 
         $this->Cell(120, $this->desc, $this->_(''), 'LR');
-        $this->Cell(50, $this->desc, $this->_('(+) Mora / Multa' . ($this->boleto[$i]->getCodigoBanco() == '104') ? ' / Juros' : ''), 'TR', 1);
+        $this->Cell(50, $this->desc, $this->_('(+) Mora / Multa' . ($this->boleto[$i]->getCodigoBanco() == '104') ? 'Multa / Juros' : ''), 'TR', 1);
 
         $this->Cell(120, $this->cell, $this->_(''), 'LR');
         $this->Cell(50, $this->cell, $this->_(''), 'R', 1);


### PR DESCRIPTION
O Boleto está sendo impresso com o label ' / Juros' quando deveria imprimir 'Multa / Juros'