### PR TITLE
Alterar data de vencimento Santander CNAB 240

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Santander.php
@@ -98,8 +98,11 @@ class Santander extends AbstractRemessa implements RemessaContract
     {
         $this->boletos[] = $boleto;
         $this->segmentoP($boleto);
-        $this->segmentoQ($boleto);
-        $this->segmentoR($boleto);
+
+        if ($boleto->getStatus() != $boleto::STATUS_ALTERACAO_DATA) {
+            $this->segmentoQ($boleto);
+            $this->segmentoR($boleto);
+        }
 
         return $this;
     }


### PR DESCRIPTION
Durante a validação com o banco, o arquivo de remessa contendo boletos com alteração de data de vencimento foram rejeitados.

Para alteração de data de vencimento, somente o segmento P do arquivo de remessa deve ser escrito.