### PR TITLE
Colocado a pré crítica da CEF como retorno..

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -894,7 +894,8 @@ final class Util
             return false;
         }
         $tipo = mb_substr($header, 142, 1);
-        if (self::isCnab240($header) && $tipo != '2' && $tipo != '3') {
+        $banco = mb_substr($header, 0, 3);
+        if (self::isCnab240($header) && $tipo != '2' && ($tipo != '3' && $banco == Contracts\Boleto\Boleto::COD_BANCO_CEF)) {
             return false;
         }
         return true;

--- a/src/Util.php
+++ b/src/Util.php
@@ -893,7 +893,8 @@ final class Util
         if (self::isCnab400($header) && mb_substr($header, 0, 9) != '02RETORNO') {
             return false;
         }
-        if (self::isCnab240($header) && mb_substr($header, 142, 1) != '2') {
+        $tipo = mb_substr($header, 142, 1);
+        if (self::isCnab240($header) && $tipo != '2' && $tipo != '3') {
             return false;
         }
         return true;

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -12,6 +12,7 @@ class UtilTest extends TestCase
         $this->assertFalse(Util::isHeaderRetorno(''));
         $this->assertFalse(Util::isHeaderRetorno(str_pad('', 400, ' ')));
         $this->assertFalse(Util::isHeaderRetorno(str_pad('', 240, ' ')));
+        $this->assertTrue(Util::isHeaderRetorno(str_pad('10400000         210598765000101000000000000000000000245673004310000000ABCDEF GHI                    CAIXA ECONOMICA FEDERAL                 322', 240, " ")));
     }
 
     public function testFuncoesString(){


### PR DESCRIPTION
A pré-crítica é o retorno da caixa que confirma se os boletos aceitos na remessa.