### PR TITLE
Arquivo de remessa Santander CNAB 240. Baixa de boleto

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Santander.php
@@ -100,7 +100,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->boletos[] = $boleto;
         $this->segmentoP($boleto);
 
-        if ($boleto->getStatus() != $boleto::STATUS_ALTERACAO_DATA) {
+        if ($boleto->getStatus() == $boleto::STATUS_REGISTRO) {
             $this->segmentoQ($boleto);
             $this->segmentoR($boleto);
         }


### PR DESCRIPTION
Segmento Q e R não devem ser escritos no arquivo de remessa quando é baixa ou alteração de data de vencimento do boleto.

Complementa o PR https://github.com/eduardokum/laravel-boleto/pull/430 já aceito

Santander
Arquivo de Remessa
CNAB 240