### PR TITLE
Alteração de data de vencimento para CNAB 240 Banco do Brasil

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -180,6 +180,12 @@ class Bb extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_ALTERACAO) {
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
+        if ($boleto->getStatus() == $boleto::STATUS_ALTERACAO_DATA) {
+            $this->add(16, 17, self::OCORRENCIA_ALT_VENCIMENTO);
+        }
+        if ($boleto->getStatus() == $boleto::STATUS_CUSTOM) {
+            $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
+        }
         $this->add(18, 22, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(23, 23, CalculoDV::bbAgencia($this->getAgencia()));
         $this->add(24, 35, Util::formatCnab('9', $this->getConta(), 12));


### PR DESCRIPTION
tipo: refactor
descrição: Arquivo de remessa com alteração de data de vencimento rejeitado pelo banco. Segmento P e segmento Q devem possuir o mesmo código de movimento de remessa. O código de alteração de data de vencimento, estava sendo escrito somente em um dos segmentos.

Documentação consultada:
https://www.bb.com.br/docs/pub/emp/empl/dwn/CbrVer04BB.pdf