### PR TITLE
php 7.3 continue

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -705,7 +705,7 @@ final class Util
             case Contracts\Boleto\Boleto::COD_BANCO_BB:
                 if (self::remove(1, 1, $detalhe) != 7) {
                     unset($retorno[$i]);
-                    continue;
+                    break;
                 }
                 self::adiciona($retorno[$i], 1, 1, '7');
                 self::adiciona($retorno[$i], 64, 80, self::remove(64, 80, $detalhe));


### PR DESCRIPTION
""continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"?"