### PR TITLE
Alteração de data de vencimento para Itaú CNAB 240

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Itau.php
@@ -95,6 +95,12 @@ class Itau extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_ALTERACAO) {
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
+        if ($boleto->getStatus() == $boleto::STATUS_ALTERACAO_DATA) {
+            $this->add(16, 17, self::OCORRENCIA_ALT_VENCIMENTO);
+        }
+        if ($boleto->getStatus() == $boleto::STATUS_CUSTOM) {
+            $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
+        }
         $this->add(18, 18, '0');
         $this->add(19, 22, Util::formatCnab('9', $this->getAgencia(), 4));
         $this->add(23, 23, '');


### PR DESCRIPTION
type: fix
description: fix em itau remessa cnab 240. Segmento P deve ter o código correto da operação. Para alteração de data de vencimento estava escrevendo como se fosse novo boleto