### PR TITLE
Correção na célula de intruções, que estoura com textos grandes

### DIFF
--- a/src/Boleto/Render/Pdf.php
+++ b/src/Boleto/Render/Pdf.php
@@ -490,7 +490,7 @@ class Pdf extends AbstractPdf implements PdfContract
     {
         foreach ($lista as $d) {
             $pulaLinha -= 2;
-            $this->MultiCell(0, $this->cell - 0.2, $this->_(preg_replace('/(%)/', '%$1', $d)), 0, 1);
+            $this->MultiCell(120, $this->cell - 0.2, $this->_(preg_replace('/(%)/', '%$1', $d)), 0, 1);
         }
 
         return $pulaLinha;


### PR DESCRIPTION
Quando estou gerando um boleto em PDF com instruções muito grandes, ele estourava a célula dessas instruções.

Corrigi esse problema na linha 492 do arquivo Pdf.php, alterando de:

`$this->MultiCell(0, $this->cell - 0.2, $this->_(preg_replace('/(%)/', '%$1', $d)), 0, 1);`

para 

`$this->MultiCell(120, $this->cell - 0.2, $this->_(preg_replace('/(%)/', '%$1', $d)), 0, 1);`