### PR TITLE
Alterações para Homologar remessa do Itaú (cnab400) 

### DIFF
--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -1096,7 +1096,7 @@ abstract class AbstractBoleto implements BoletoContract
      */
     public function getMoraDia()
     {
-        if (!$this->getJuros() > 0) {
+        if (!$this->getJuros() < 0) {
            return 0;
         }
         return Util::percent($this->getValor(), $this->getJuros())/30;

--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -1096,7 +1096,7 @@ abstract class AbstractBoleto implements BoletoContract
      */
     public function getMoraDia()
     {
-        if (!$this->getJuros() < 0) {
+        if ($this->getJuros() <= 0) {
            return 0;
         }
         return Util::percent($this->getValor(), $this->getJuros())/30;

--- a/src/Boleto/Banco/Itau.php
+++ b/src/Boleto/Banco/Itau.php
@@ -141,4 +141,12 @@ class Itau extends AbstractBoleto implements BoletoContract
             'contaCorrenteDv' => substr($campoLivre, 21, 1),
         ];
     }
+    /**
+     * Método que retorna o digito da conta do Itau
+     *
+     * @return int
+     */
+    public function getContaDv(){
+        return  CalculoDV::itauContaCorrente($this->getAgencia(), $this->getConta());
+    }
 }

--- a/src/Boleto/Banco/Itau.php
+++ b/src/Boleto/Banco/Itau.php
@@ -147,6 +147,8 @@ class Itau extends AbstractBoleto implements BoletoContract
      * @return int
      */
     public function getContaDv(){
+        if($this->contaDv !== NULL)
+            return $this->contaDv;
         return  CalculoDV::itauContaCorrente($this->getAgencia(), $this->getConta());
     }
 }

--- a/src/Cnab/Remessa/Cnab400/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Itau.php
@@ -180,7 +180,7 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(18, 21, Util::formatCnab('9', $this->getAgencia(), 4));
         $this->add(22, 23, '00');
         $this->add(24, 28, Util::formatCnab('9', $this->getConta(), 5));
-        $this->add(29, 29, $this->getContaDv() ?: CalculoDV::itauContaCorrente($this->getAgencia(), $this->getContaDv()));
+        $this->add(29, 29, $this->getContaDv() ?: CalculoDV::itauContaCorrente($this->getAgencia(), $this->getConta()));
         $this->add(30, 33, '');
         $this->add(34, 37, '0000');
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle


### PR DESCRIPTION
Durante a homologação com o Itaú para um cliente, houveram dois erros:

> A representação gráfica do boleto no campo  "Agência/Código beneficiário"  deve ser AAAA/CCCCC-D onde,  AAAA=Número da agência,  CCCCC=Número da conta corrente e  D=Dac da agência/conta.  Recomendamos não deixar espaços entre os caracteres, incluindo a barra (/) e o hífen (-); 
> 
> O DAC da conta corrente informado no registro de detalhe na posição 29 do arquivo remessa está errado.

O primeiro era porque eu não havia colocado o campo contaDv no boleto na hora de criação, já que segui pela documentação. Para manter fiel à documentação, achei melhor sobrescrever o método getContaDv do boleto/itau.php para calcular caso não esteja indicado.

O segundo erro era por conta de um bug. Nó método do cálculo do dígito é preciso a agência e conta, e ele estava passando o dígito da conta.

Após as modificações, o ambiente do cliente foi homologado.

Além disso, consertei um bug que fazia com que os juros sempre fossem nulos nos arquivos de remessa.