### PR TITLE
Divisão das espécies do Santander nas remessas 240 e 400

### DIFF
--- a/src/Boleto/Banco/Santander.php
+++ b/src/Boleto/Banco/Santander.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Eduardokum\LaravelBoleto\Boleto\Banco;
 
 use Eduardokum\LaravelBoleto\Boleto\AbstractBoleto;
@@ -6,7 +7,7 @@ use Eduardokum\LaravelBoleto\CalculoDV;
 use Eduardokum\LaravelBoleto\Contracts\Boleto\Boleto as BoletoContract;
 use Eduardokum\LaravelBoleto\Util;
 
-class Santander  extends AbstractBoleto implements BoletoContract
+class Santander extends AbstractBoleto implements BoletoContract
 {
     public function __construct(array $params = [])
     {
@@ -27,22 +28,37 @@ class Santander  extends AbstractBoleto implements BoletoContract
      */
     protected $carteiras = ['101', '201'];
     /**
-     * Espécie do documento, coódigo para remessa
+     * Espécie do documento, código para remessa 240
      *
      * @var string
      */
-    protected $especiesCodigo = [
-        'DM' => '02',
-        'DS' => '04',
-        'LC' => '07',
-        'NP' => '12',
-        'NR' => '13',
-        'RC' => '17',
-        'AP' => '20',
-        'BCC'=> '31',
-        'BDP'=> '32',
-        'CH' => '97',
-        'ND' => '98'
+    protected $especiesCodigo240 = [
+        'DM'  => '02',
+        'DS'  => '04',
+        'LC'  => '07',
+        'NP'  => '12',
+        'NR'  => '13',
+        'RC'  => '17',
+        'AP'  => '20',
+        'BCC' => '31',
+        'BDP' => '32',
+        'CH'  => '97',
+        'ND'  => '98'
+    ];
+    /**
+     * Espécie do documento, código para remessa 400
+     *
+     * @var string
+     */
+    protected $especiesCodigo400 = [
+        'DM'  => '01',
+        'NP'  => '02',
+        'AP'  => '03',
+        'RC'  => '05',
+        'DP'  => '06',
+        'LC'  => '07',
+        'BDP' => '08',
+        'BCC' => '19',
     ];
     /**
      * Define os nomes das carteiras para exibição no boleto
@@ -93,7 +109,8 @@ class Santander  extends AbstractBoleto implements BoletoContract
      * Retorna o código da carteira
      * @return string
      */
-    public function getCarteiraNumero(){
+    public function getCarteiraNumero()
+    {
         switch ($this->carteira) {
             case '101':
                 $carteira = '5';
@@ -136,23 +153,24 @@ class Santander  extends AbstractBoleto implements BoletoContract
     /**
      * Define o código da carteira (Com ou sem registro)
      *
-     * @param  string $carteira
+     * @param string $carteira
      * @return AbstractBoleto
      * @throws \Exception
      */
     public function setCarteira($carteira)
     {
         switch ($carteira) {
-        case '1':
-        case '5':
-            $carteira = '101';
-            break;
-        case '4':
-            $carteira = '102';
-            break;
+            case '1':
+            case '5':
+                $carteira = '101';
+                break;
+            case '4':
+                $carteira = '102';
+                break;
         }
         return parent::setCarteira($carteira);
     }
+
     /**
      * Define o valor do IOS
      *
@@ -162,6 +180,7 @@ class Santander  extends AbstractBoleto implements BoletoContract
     {
         $this->ios = $ios;
     }
+
     /**
      * Retorna o atual valor do IOS
      *
@@ -188,10 +207,11 @@ class Santander  extends AbstractBoleto implements BoletoContract
         if (!in_array($baixaAutomatica, [15, 30])) {
             throw new \Exception('O Banco Santander so aceita 15 ou 30 dias após o vencimento para baixa automática');
         }
-        $baixaAutomatica = (int) $baixaAutomatica;
+        $baixaAutomatica = (int)$baixaAutomatica;
         $this->diasBaixaAutomatica = $baixaAutomatica > 0 ? $baixaAutomatica : 0;
         return $this;
     }
+
     /**
      * Gera o Nosso Número.
      *
@@ -203,6 +223,7 @@ class Santander  extends AbstractBoleto implements BoletoContract
         return Util::numberFormatGeral($numero_boleto, 12)
             . CalculoDV::santanderNossoNumero($numero_boleto);
     }
+
     /**
      * Método para gerar o código da posição de 20 a 44
      *
@@ -226,18 +247,19 @@ class Santander  extends AbstractBoleto implements BoletoContract
      *
      * @return array
      */
-    public static function parseCampoLivre($campoLivre) {
+    public static function parseCampoLivre($campoLivre)
+    {
         return [
-            'convenio' => null,
-            'agencia' => null,
-            'agenciaDv' => null,
-            'contaCorrente' => null,
+            'convenio'        => null,
+            'agencia'         => null,
+            'agenciaDv'       => null,
+            'contaCorrente'   => null,
             'contaCorrenteDv' => null,
-            'codigoCliente' => substr($campoLivre, 1, 7),
-            'nossoNumero' => substr($campoLivre, 8, 12),
-            'nossoNumeroDv' => substr($campoLivre, 20, 1),
+            'codigoCliente'   => substr($campoLivre, 1, 7),
+            'nossoNumero'     => substr($campoLivre, 8, 12),
+            'nossoNumeroDv'   => substr($campoLivre, 20, 1),
             'nossoNumeroFull' => substr($campoLivre, 8, 13),
-            'carteira' => substr($campoLivre, 22, 3),
+            'carteira'        => substr($campoLivre, 22, 3),
         ];
     }
 }

--- a/src/Boleto/Banco/Santander.php
+++ b/src/Boleto/Banco/Santander.php
@@ -61,6 +61,12 @@ class Santander extends AbstractBoleto implements BoletoContract
         'BCC' => '19',
     ];
     /**
+     * Mostrar o endereço do beneficiário abaixo da razão e CNPJ na ficha de compensação
+     *
+     * @var boolean
+     */
+    protected $mostrarEnderecoFichaCompensacao = true;
+    /**
      * Define os nomes das carteiras para exibição no boleto
      *
      * @var array

--- a/src/Cnab/Remessa/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Santander.php
@@ -155,7 +155,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(101, 104, Util::formatCnab('9', 0, 4));
         $this->add(105, 105, Util::formatCnab('9', 0, 1));
         $this->add(106, 106, '');
-        $this->add(107, 108, Util::formatCnab('9', $boleto->getEspecieDocCodigo(), 2));
+        $this->add(107, 108, Util::formatCnab('9', $boleto->getEspecieDocCodigo('02', 240), 2));
         $this->add(109, 109, Util::formatCnab('9', 'N', 1));
         $this->add(110, 117, $boleto->getDataDocumento()->format('dmY'));
         $this->add(118, 118, ($boleto->getJuros() !== null && $boleto->getJuros() > 0) ? '2' : '3');    //3 = ISENTO | 1 = R$ ao dia | 2 = % ao mês

--- a/src/Cnab/Remessa/Cnab400/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Santander.php
@@ -197,7 +197,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(127, 139, Util::formatCnab('9', $boleto->getValor(), 13, 2));
         $this->add(140, 142, $this->getCodigoBanco());
         $this->add(143, 147, '00000');
-        $this->add(148, 149, $boleto->getEspecieDocCodigo());
+        $this->add(148, 149, $boleto->getEspecieDocCodigo('01', '400'));
         $this->add(150, 150, $boleto->getAceite());
         $this->add(151, 156, $boleto->getDataDocumento()->format('dmy'));
         $this->add(157, 158, self::INSTRUCAO_SEM);


### PR DESCRIPTION
A homologação dos boletos com no padrão 400 estão sendo recusados.
Identifiquei que as espécies das remessas 240 e 400 são diferentes.
Fiz a divisão das espécies de acordo com cada layout assim como a PR #471 

E também é obrigatório exibir o endereço na ficha de compensação. Adicionei o $mostrarEnderecoFichaCompensacao como true