### PR TITLE
Flexibilizando instruções de cobrança 1 e 2

### DIFF
--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -239,6 +239,18 @@ abstract class AbstractBoleto implements BoletoContract
      */
     protected $instrucoes_impressao = [];
     /**
+     * String com a instrução de cobrança 1
+     *
+     * @var string
+     */
+    protected $instrucao_cobranca_1 = '';
+    /**
+     * String com a instrução de cobrança 2
+     *
+     * @var string
+     */
+    protected $instrucao_cobranca_2 = '';
+    /**
      * Localização do logotipo do banco, referente ao diretório de imagens
      *
      * @var string
@@ -911,6 +923,56 @@ abstract class AbstractBoleto implements BoletoContract
     public function getDescricaoDemonstrativo()
     {
         return array_slice((array)$this->descricaoDemonstrativo + [null, null, null, null, null], 0, 5);
+    }
+
+    /**
+     * Define uma string com a instrução de cobrança 1
+     *
+     * @param string $instrucao_cobranca_1
+     *
+     * @return AbstractBoleto
+     * @throws \Exception
+     */
+    public function setInstrucaoCobranca1(string $instrucao_cobranca_1)
+    {
+        $this->instrucao_cobranca_1 = $instrucao_cobranca_1;
+
+        return $this;
+    }
+
+    /**
+     * Retorna uma string com a instrução de cobrança 1
+     *
+     * @return string
+     */
+    public function getInstrucaoCobranca1()
+    {
+        return $this->instrucao_cobranca_1;
+    }
+
+    /**
+     * Define uma string com a instrução de cobrança 2
+     *
+     * @param string $instrucao_cobranca_2
+     *
+     * @return AbstractBoleto
+     * @throws \Exception
+     */
+    public function setInstrucaoCobranca2(string $instrucao_cobranca_2)
+    {
+        $this->instrucao_cobranca_2 = $instrucao_cobranca_2;
+
+        return $this;
+    }
+
+    /**
+     * Retorna uma string com a instrução de cobrança 2
+     *
+     * @return string
+     */
+    public function getInstrucaoCobranca2()
+    {
+        return $this->instrucao_cobranca_2;
     }
 
     /**

--- a/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
@@ -275,8 +275,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(148, 149, $this->isCarteiraRSX() ? '' : self::TIPO_COBRANCA_CREDENCIADA);
         $this->add(150, 150, $boleto->getAceite());
         $this->add(151, 156, $boleto->getDataDocumento()->format('dmy'));
-        $this->add(157, 158, self::INSTRUCAO_SEM);
-        $this->add(159, 160, self::INSTRUCAO_SEM);
+        $this->add(157, 158, $boleto->getInstrucaoCobranca1() ?: self::INSTRUCAO_SEM);
+        $this->add(159, 160, $boleto->getInstrucaoCobranca2() ?: self::INSTRUCAO_VALOR_SOMA_MORA);
         if ($boleto->getDiasProtesto() > 0) {
             $this->add(157, 158, self::INSTRUCAO_PROTESTAR_XX);
         } elseif ($boleto->getDiasBaixaAutomatica() > 0) {

--- a/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
@@ -209,8 +209,8 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(148, 149, $boleto->getEspecieDocCodigo());
         $this->add(150, 150, 'N');
         $this->add(151, 156, $boleto->getDataDocumento()->format('dmy'));
-        $this->add(157, 158, self::INSTRUCAO_SEM);
-        $this->add(159, 160, self::INSTRUCAO_SEM);
+        $this->add(157, 158, $boleto->getInstrucaoCobranca1() ?: self::INSTRUCAO_SEM);
+        $this->add(159, 160, $boleto->getInstrucaoCobranca2() ?: self::INSTRUCAO_VALOR_SOMA_MORA);
         if ($boleto->getDiasProtesto() > 0) {
             $this->add(157, 158, self::INSTRUCAO_PROTESTAR_XX);
             $this->add(159, 160, Util::formatCnab('9', $boleto->getDiasProtesto(), 2));

--- a/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
@@ -183,8 +183,8 @@ class Caixa  extends AbstractRemessa implements RemessaContract
         $this->add(148, 149, $boleto->getEspecieDocCodigo());
         $this->add(150, 150, $boleto->getAceite());
         $this->add(151, 156, $boleto->getDataDocumento()->format('dmy'));
-        $this->add(157, 158, self::INSTRUCAO_SEM);
-        $this->add(159, 160, self::INSTRUCAO_SEM);
+        $this->add(157, 158, $boleto->getInstrucaoCobranca1() ?: self::INSTRUCAO_SEM);
+        $this->add(159, 160, $boleto->getInstrucaoCobranca2() ?: self::INSTRUCAO_VALOR_SOMA_MORA);
         if ($boleto->getDiasProtesto() > 0) {
             $this->add(157, 158, self::INSTRUCAO_PROTESTAR_VENC_XX);
         } elseif ($boleto->getDiasBaixaAutomatica() > 0) {

--- a/src/Cnab/Remessa/Cnab400/Banco/Hsbc.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Hsbc.php
@@ -189,8 +189,8 @@ class Hsbc extends AbstractRemessa implements RemessaContract
         $this->add(148, 149, $boleto->getEspecieDocCodigo());
         $this->add(150, 150, $boleto->getAceite());
         $this->add(151, 156, $boleto->getDataDocumento()->format('dmy'));
-        $this->add(157, 158, self::INSTRUCAO_SEM);
-        $this->add(159, 160, self::INSTRUCAO_SEM);
+        $this->add(157, 158, $boleto->getInstrucaoCobranca1() ?: self::INSTRUCAO_SEM);
+        $this->add(159, 160, $boleto->getInstrucaoCobranca2() ?: self::INSTRUCAO_VALOR_SOMA_MORA);
         if ($boleto->getDiasProtesto() > 0) {
             $this->add(157, 158, self::INSTRUCAO_PROTESTAR_XX_VENC_UTEIS);
         }

--- a/src/Cnab/Remessa/Cnab400/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Itau.php
@@ -210,8 +210,8 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(148, 149, $boleto->getEspecieDocCodigo());
         $this->add(150, 150, $boleto->getAceite());
         $this->add(151, 156, $boleto->getDataDocumento()->format('dmy'));
-        $this->add(157, 158, self::INSTRUCAO_SEM);
-        $this->add(159, 160, self::INSTRUCAO_VALOR_SOMA_MORA);
+        $this->add(157, 158, $boleto->getInstrucaoCobranca1() ?: self::INSTRUCAO_SEM);
+        $this->add(159, 160, $boleto->getInstrucaoCobranca2() ?: self::INSTRUCAO_VALOR_SOMA_MORA);
         if ($boleto->getDiasProtesto() > 0) {
             $this->add(157, 158, self::INSTRUCAO_PROTESTAR_VENC_XX);
         } elseif ($boleto->getDiasBaixaAutomatica() > 0) {

--- a/src/Cnab/Remessa/Cnab400/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Santander.php
@@ -200,8 +200,8 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(148, 149, $boleto->getEspecieDocCodigo());
         $this->add(150, 150, $boleto->getAceite());
         $this->add(151, 156, $boleto->getDataDocumento()->format('dmy'));
-        $this->add(157, 158, self::INSTRUCAO_SEM);
-        $this->add(159, 160, self::INSTRUCAO_SEM);
+        $this->add(157, 158, $boleto->getInstrucaoCobranca1() ?: self::INSTRUCAO_SEM);
+        $this->add(159, 160, $boleto->getInstrucaoCobranca2() ?: self::INSTRUCAO_VALOR_SOMA_MORA);
         if ($boleto->getDiasProtesto() > 0) {
             $this->add(157, 158, self::INSTRUCAO_PROTESTAR);
         } elseif ($boleto->getDiasBaixaAutomatica() == 15) {

--- a/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
@@ -166,8 +166,8 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(149, 149, $boleto->getEspecieDocCodigo('A', 400));
         $this->add(150, 150, $boleto->getAceite());
         $this->add(151, 156, $boleto->getDataDocumento()->format('dmy'));
-        $this->add(157, 158, self::INSTRUCAO_SEM);
-        $this->add(159, 160, self::INSTRUCAO_SEM);
+        $this->add(157, 158, $boleto->getInstrucaoCobranca1() ?: self::INSTRUCAO_SEM);
+        $this->add(159, 160, $boleto->getInstrucaoCobranca2() ?: self::INSTRUCAO_VALOR_SOMA_MORA);
         if ($boleto->getDiasProtesto() > 0) {
             $this->add(157, 158, self::INSTRUCAO_PROTESTO);
             $this->add(159, 160, Util::formatCnab('9', $boleto->getDiasProtesto(), 2));

--- a/src/Contracts/Boleto/Boleto.php
+++ b/src/Contracts/Boleto/Boleto.php
@@ -182,6 +182,16 @@ interface Boleto
     /**
      * @return mixed
      */
+    public function getInstrucaoCobranca1();
+
+    /**
+     * @return mixed
+     */
+    public function getInstrucaoCobranca2();
+
+    /**
+     * @return mixed
+     */
     public function getLocalPagamento();
 
     /**


### PR DESCRIPTION
Verifiquei a necessidade de usar os campos instruções de cobrança (CNAB400), posições 157-158, 159-160 de uma forma mais fácil. Tinha feito essa implementação há alguns dias mas esqueci de enviar.

@eduardokum Poderia verificar?