### PR TITLE
Tipo de juros e desconto

### DIFF
--- a/src/Cnab/Remessa/AbstractRemessa.php
+++ b/src/Cnab/Remessa/AbstractRemessa.php
@@ -124,6 +124,20 @@ abstract class AbstractRemessa
     protected $beneficiario;
 
     /**
+     * Tipo de juros. (A: Valor, B: Percentual)
+     *
+     * @var
+     */
+    protected $tipoJuros = 'A';
+
+    /**
+     * Tipo de desconto. (A: Valor, B: Percentual)
+     *
+     * @var
+     */
+    protected $tipoDesconto = 'A';
+
+    /**
      * Construtor
      *
      * @param array $params Parâmetros iniciais para construção do objeto
@@ -334,6 +348,54 @@ abstract class AbstractRemessa
     public function getCarteiras()
     {
         return $this->carteiras;
+    }
+
+    /**
+     * Define o tipo de juros
+     *
+     * @return string
+     */
+    public function setTipoJuros($tipoJuros)
+    {
+        if (! in_array($tipoJuros, ['A', 'B'])) {
+            throw new \Exception("Tipo de juros incorreto!");
+        }
+        $this->tipoJuros = $tipoJuros;
+        return $this;
+    }
+
+    /**
+     * Retorna o tipo de juros
+     *
+     * @return string
+     */
+    public function getTipoJuros()
+    {
+        return $this->tipoJuros;
+    }
+
+    /**
+     * Define o tipo de desconto
+     *
+     * @return string
+     */
+    public function setTipoDesconto($tipoDesconto)
+    {
+        if (! in_array($tipoDesconto, ['A', 'B'])) {
+            throw new \Exception("Tipo de desconto incorreto!");
+        }
+        $this->tipoDesconto = $tipoDesconto;
+        return $this;
+    }
+
+    /**
+     * Retorna o tipo de desconto
+     *
+     * @return string
+     */
+    public function getTipoDesconto()
+    {
+        return $this->tipoDesconto;
     }
 
     /**

--- a/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
@@ -121,8 +121,8 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(4, 4, 'A');
         $this->add(5, 16, '');
         $this->add(17, 17, 'A');
-        $this->add(18, 18, 'A');
-        $this->add(19, 19, 'A');
+        $this->add(18, 18, $this->getTipoDesconto());
+        $this->add(19, 19, $this->getTipoJuros());
         $this->add(20, 47, '');
         $this->add(48, 56, Util::formatCnab('9', $boleto->getNossoNumero(), 9));
         $this->add(57, 62, '');


### PR DESCRIPTION
implementados métodos para escolher se tipo de juros ou desconto são em R$ ou %, apenas para CNAB 400 do banco sicredi