### PR TITLE
Width barras menor p padronizar com outros boletos

### DIFF
--- a/src/Boleto/Render/Pdf.php
+++ b/src/Boleto/Render/Pdf.php
@@ -393,7 +393,7 @@ class Pdf extends AbstractPdf implements PdfContract
     {
         $this->Ln(3);
         $this->Cell(0, 15, '', 0, 1, 'L');
-        $this->i25($this->GetX(), $this->GetY() - 15, $this->boleto[$i]->getCodigoBarras(), 0.8, 17);
+        $this->i25($this->GetX(), $this->GetY() - 15, $this->boleto[$i]->getCodigoBarras(), 1, 17);
     }
 
     /**


### PR DESCRIPTION
Parabéns desde já pelo projeto!

Sugestão de mudança na função **codigoBarras($i)** em Render\Pdf.php

Parâmetro **0.8** está deixando as barras muito grandes e fora de padrão de outros boletos gerados pelo banco.

Sugestão para mudar para **1** que ficou igual ao padrão dos bancos.
