### PR TITLE
Alterando str_random(32) para Str::random(32)

### DIFF
--- a/src/Boleto/Render/Pdf.php
+++ b/src/Boleto/Render/Pdf.php
@@ -5,6 +5,7 @@ namespace Eduardokum\LaravelBoleto\Boleto\Render;
 use Eduardokum\LaravelBoleto\Contracts\Boleto\Boleto as BoletoContract;
 use Eduardokum\LaravelBoleto\Contracts\Boleto\Render\Pdf as PdfContract;
 use Eduardokum\LaravelBoleto\Util;
+use Illuminate\Support\Str;
 
 class Pdf extends AbstractPdf implements PdfContract
 {
@@ -474,7 +475,7 @@ class Pdf extends AbstractPdf implements PdfContract
             return $save_path;
         }
         if ($nameFile == null) {
-            $nameFile = str_random(32);
+            $nameFile = Str::random(32);
         }
         
         return $this->Output($nameFile . '.pdf', $dest, $this->print);


### PR DESCRIPTION
Na geração do boleto sem passar o nome, da erro pois a str_random não existe mais a partir da versão 6 do laravel.