### PR TITLE
Ajusta valor de tarifa do CNAB240 de Retorno da Santander

### DIFF
--- a/src/Cnab/Retorno/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Retorno/Cnab240/Banco/Santander.php
@@ -263,7 +263,6 @@ class Santander extends AbstractRetorno implements RetornoCnab240
                 ->setValorAbatimento(Util::nFloat($this->rem(48, 62, $detalhe)/100, 2, false))
                 ->setValorIOF(Util::nFloat($this->rem(63, 77, $detalhe)/100, 2, false))
                 ->setValorRecebido(Util::nFloat($this->rem(78, 92, $detalhe)/100, 2, false))
-                ->setValorTarifa($d->getValorRecebido() - Util::nFloat($this->rem(93, 107, $detalhe)/100, 2, false))
                 ->setDataOcorrencia($this->rem(138, 145, $detalhe))
                 ->setDataCredito($this->rem(146, 153, $detalhe));
         }


### PR DESCRIPTION
Remove calculo de tarifa do Segmento U, buscando a informacao do Segmento T para solucionar problema relatado no issue #522 