### PR TITLE
Corrige informação de Agência/Código Beneficiário (Boleto BB)

### DIFF
--- a/src/Boleto/Banco/Bb.php
+++ b/src/Boleto/Banco/Bb.php
@@ -87,7 +87,7 @@ class Bb extends AbstractBoleto implements BoletoContract
     public function getAgenciaCodigoBeneficiario()
     {
         $agencia = $this->getAgencia() . '-' . CalculoDV::bbAgencia($this->getAgencia());
-        $codigoCliente = $this->getConvenio();
+        $codigoCliente = $this->getConta() . '-' . CalculoDV::bbContaCorrente($this->getConta());
 
         return $agencia . ' / ' . $codigoCliente;
     }


### PR DESCRIPTION
Estava apresentando o número do convênio e não o número da conta.