### PR TITLE
Atualização nos códigos de especieDoc

### DIFF
--- a/src/Boleto/Banco/Bradesco.php
+++ b/src/Boleto/Banco/Bradesco.php
@@ -45,39 +45,16 @@ class Bradesco  extends AbstractBoleto implements BoletoContract
      * @var string
      */
     protected $especiesCodigo = [
-        'CH'  => '01', //Cheque
-        'DM'  => '02', //Duplicata Mercantil
-        'DMI' => '03', //Duplicata Mercantil p/ Indicação
-        'DS'  => '04', //Duplicata de Serviço
-        'DSI' => '05', //Duplicata de Serviço p/ Indicação
-        'DR'  => '06', //Duplicata Rural
-        'LC'  => '07', //Letra de Câmbio
-        'NCC' => '08', //Nota de Crédito Comercial
-        'NCE' => '09', //Nota de Crédito a Exportação
-        'NCI' => '10', //Nota de Crédito Industrial
-        'NCR' => '11', //Nota de Crédito Rural
-        'NP'  => '12', //Nota Promissória
-        'NPR' => '13', //Nota Promissória Rural
-        'TM'  => '14', //Triplicata Mercantil
-        'TS'  => '15', //Triplicata de Serviço
-        'NS'  => '16', //Nota de Seguro
-        'RC'  => '17', //Recibo
-        'FAT' => '18', //Fatura
-        'ND'  => '19', //Nota de Débito
-        'AP'  => '20', //Apólice de Seguro
-        'ME'  => '21', //Mensalidade Escolar
-        'PC'  => '22', //Parcela de Consórcio
-        'NF'  => '23', //Nota Fiscal
-        'DD'  => '24', //Documento de Dívida
-        'CPR' => '25', //Cédula de Produto Rural,
-        'WAR' => '26', //Warrant
-        'DAE' => '27', //Dívida Ativa do Estado
-        'DAM' => '28', //Dívida Ativa do Município
-        'DAU' => '29', //Dívida Ativa da União
-        'EC'  => '30', //Encargos condominiais
-        'CC'  => '31', //CC Cartão de Crédito,
-        'BDP' => '32', //BDP - Boleto de Proposta
-        'O'   => '99', //Outros,
+        'DM' => '01', //Duplicata
+        'NP' => '02', //Nota Promissória
+        'NS' => '03', //Nota de Seguro
+        'CS' => '04', //Cobrança Seriada
+        'RC' => '05', //Recibo
+        'LC' => '10', //Letras de Câmbio
+        'ND' => '11', //Nota de Débito
+        'DS' => '12', //Duplicata de Serv.
+        'BP' => '30', //Boleto de Proposta
+        'O'  => '99', //Outros,
     ];
     /**
      * Mostrar o endereço do beneficiário abaixo da razão e CNPJ na ficha de compensação


### PR DESCRIPTION
Emitindo boletos para o Bradesco com a tabela atual informando 'DM' o registro estava chegando como 'NP' no banco.

De acordo com a tabela na página 11 do manual, esses são os códigos atualizados para emissão do boleto:
https://github.com/eduardokum/laravel-boleto/blob/master/manuais/BRADESCO/novos/400_posicoes.pdf