### PR TITLE
Emitir o arquivo de remessa cnab400 banco do brasil.

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bb.php
@@ -277,7 +277,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(157, 158, $boleto->getStatus() == $boleto::STATUS_BAIXA ? self::INSTRUCAO_BAIXAR : self::INSTRUCAO_SEM);
         $this->add(159, 160, self::INSTRUCAO_SEM);
         $diasProtesto = '00';
-        $const = sprintf('self::INSTRUCAO_PROTESTAR_VENC_%02s', $boleto->getDiasProtesto());
+        $const = $boleto->getDiasProtesto() > 0 ? sprintf('self::INSTRUCAO_PROTESTAR_VENC_%02s', $boleto->getDiasProtesto()) : 'self::INSTRUCAO_NAO_PROTESTAR';
         if ($boleto->getStatus() != $boleto::STATUS_BAIXA) {
             if (defined($const)) {
                 $this->add(157, 158, constant($const));


### PR DESCRIPTION
Ao tentar emitir o arquivo de remessa cnab400 banco do brasil, com o dado dias_protesto com o valor 0. Foi identificado que na biblioteca não existia uma condição para não protestar quando dias_protesto for igual a 0. No qual adicionado a biblioteca a seguinte condição :

$const = $boleto->getDiasProtesto() > 0 ? sprintf('self::INSTRUCAOPROTESTAR_VENC%02s', $boleto->getDiasProtesto()) : 'self::INSTRUCAO_NAO_PROTESTAR';