### PR TITLE
Atualizado local de pagamento padrão para Bancoob

### DIFF
--- a/src/Boleto/Banco/Bancoob.php
+++ b/src/Boleto/Banco/Bancoob.php
@@ -25,6 +25,12 @@ class Bancoob extends AbstractBoleto implements BoletoContract
      */
     protected $carteiras = ['1','3'];
     /**
+     * Linha de local de pagamento
+     *
+     * @var string
+     */
+    protected $localPagamento = 'Pagável Preferencialmente no Sicoob';
+    /**
      * Espécie do documento, código para remessa do CNAB240
      * @var string
      */


### PR DESCRIPTION
Na última vez que precisei validar com o Bancood/Sicoob, eles solicitaram para que o local de pagamento seja "Pagável Preferencialmente no Sicoob"