### PR TITLE
Adicionado +1 dia para data de multa no Bancoob

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Bancoob.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bancoob.php
@@ -240,7 +240,8 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->add(43, 50, '00000000');
         $this->add(51, 65, '000000000000000');
         $this->add(66, 66, $boleto->getMulta() > 0 ? '2' : '0'); //0 = ISENTO | 1 = VALOR FIXO | 2 = PERCENTUAL
-        $this->add(67, 74, $boleto->getMulta() > 0 ?  $boleto->getDataVencimento()->format('dmY') : '00000000');        $this->add(75, 89, Util::formatCnab('9', $boleto->getMulta(), 15, 2));  //2,20 = 0000000000220
+        $this->add(67, 74, $boleto->getMulta() > 0 ?  $boleto->getDataVencimento()->copy()->addDays($boleto->getJurosApos() ?: 1)->format('dmY') : '00000000');
+        $this->add(75, 89, Util::formatCnab('9', $boleto->getMulta(), 15, 2));  //2,20 = 0000000000220
         $this->add(90, 199, '');
         $this->add(200, 207, '00000000');
         $this->add(208, 210, '000');


### PR DESCRIPTION
Na última validação com o banco Bancoob/Sicoob, solicitaram para que a data a multa seja no mínimo d+1