### PR TITLE
correção para calculo do dígito verificador de boletos itaú em carteiras escriturais

### DIFF
--- a/src/CalculoDV.php
+++ b/src/CalculoDV.php
@@ -165,12 +165,12 @@ class CalculoDV
 			}else{
 				$dv1++;
 			}
-			
-			$dv2 = Util::modulo11($campo . $dv1, 2, 7, 0, 10);				
+
+			$dv2 = Util::modulo11($campo . $dv1, 2, 7, 0, 10);
 		}elseif($dv2 != 0){
 			$dv2 = (11 - $dv2);
 		}
-			
+
 		return $dv1 . $dv2;
     }
 
@@ -206,7 +206,7 @@ class CalculoDV
         $dv = Util::modulo11($agencia, 2, 9, 0, 'P');
         return $dv == 11 ? 0 : $dv;
     }
-    
+
     public static function bradescoContaCorrente($contaCorrente)
     {
         return Util::modulo11($contaCorrente, 2, 9, 0, 'P');
@@ -235,6 +235,12 @@ class CalculoDV
             . Util::numberFormatGeral($conta, 5)
             . Util::numberFormatGeral($carteira, 3)
             . Util::numberFormatGeral($numero_boleto, 8);
+
+        if (in_array($carteira, [112, 126, 131, 145, 150, 168])) {
+            $n = Util::numberFormatGeral($carteira, 3)
+                . Util::numberFormatGeral($numero_boleto, 8);
+        }
+
         return Util::modulo10($n);
     }
 


### PR DESCRIPTION
correção realizada para calculo do dígito verificador de boletos itaú em carteiras escriturais.
Identifiquei o problema ao constatar que a linha digitável dos boletos estavam ficando divergentes das geras através do banco.

ao gerar boletos para a carteira 112 itaú, tive uma divergência na geração do dígito verificador do nosso número, no caso em que eu estava testando gerava número 7 sendo que o número do boleto que foi impresso no banco era 9.

Após um tempo de pesquisa encontrei este documento que exibe a formula para a geração do digito verificador do nosso número para o itaú:
[https://download.itau.com.br/bankline/cobranca_cnab240.pdf](https://download.itau.com.br/bankline/cobranca_cnab240.pdf)
página 30 - título: (27) DÍGITO DO NOSSO NÚMERO
Onde é informado que para a geração do digito verificador nas carteiras: 126, 131, 145, 150 e 168 e escriturais, deve ser utilizado somente carteira e número do boleto para a geração do digito verificador.