### PR TITLE
Nova carteira para remessa Bradesco

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
@@ -72,7 +72,7 @@ class Bradesco extends AbstractRemessa implements RemessaContract
      * @var array
      */
 
-    protected $carteiras = ['04', '09', '28'];
+    protected $carteiras = ['02', '04', '09', '28'];
 
     /**
      * Caracter de fim de linha


### PR DESCRIPTION
Adicionei a carteira "02" a lista de de carteiras disponíveis para remessa Bradesco. Essa foi a carteira que o Bradesco orientou a usar na empresa a qual estou fazendo a homologação dos boletos e remessa de cobrança.