### PR TITLE
arquivo de retorno: cria campo para valorOutrasDespesas; tratamento para ocorrências '28 - Tarifas' do CNAB400 do Sicredi não serem consideradas erro

### DIFF
--- a/src/Cnab/Retorno/Cnab240/Banco/Bancoob.php
+++ b/src/Cnab/Retorno/Cnab240/Banco/Bancoob.php
@@ -282,7 +282,23 @@ class Bancoob extends AbstractRetorno implements RetornoCnab240
 
         if ($this->getSegmentType($detalhe) == 'T') {
             $d->setOcorrencia($this->rem(16, 17, $detalhe))
-                ->setOcorrenciaDescricao(Arr::get($this->ocorrencias, $this->detalheAtual()->getOcorrencia(), 'Desconhecida'))
+                ->setOcorrenciaDescricao(Arr::get($this->ocorrencias, $this->detalheAtual()->getOcorrencia(), 'Desconhecida'));
+
+            /**
+             * Conforme Manual o campo Nosso Número deve ter 7 dígitos + 1DV.
+             * Ao enviar a remessa formatamos para 10 dígitos preenchendo com zeros a esquerda
+             * Da mesma forma, no arquivo retorno, volta com 10 dígitos.
+             * Portanto, as duas primeiras, posições 38 e 39 serão sempre 00,
+             * seguidos de 7 dígitos + 1 dígito DV = 8 digitos da posição 40 até a 47.
+             *
+             * Para voltar a considerar 10 digitos voltar  trecho de código.
+             * ////->setNossoNumero($this->rem(38, 47, $detalhe))
+             *
+             */
+            if ( $this->rem(38, 39, $detalhe) != "00"){
+                throw new \Exception("Verificar arquivo retorno:  O nosso número no arquivo de retorno é maior que 7 dígitos.");
+            }
+            $d->setNossoNumero($this->rem(40, 47, $detalhe))
                 ->setNossoNumero($this->rem(38, 47, $detalhe))
                 ->setCarteira($this->rem(58, 58, $detalhe))
                 ->setNumeroDocumento($this->rem(59, 73, $detalhe))

--- a/src/Cnab/Retorno/Cnab240/Detalhe.php
+++ b/src/Cnab/Retorno/Cnab240/Detalhe.php
@@ -78,6 +78,11 @@ class Detalhe implements DetalheContract
     /**
      * @var string
      */
+    protected $valorOutrasDespesas;
+
+    /**
+     * @var string
+     */
     protected $valorIOF;
     /**
      * @var string
@@ -512,6 +517,26 @@ class Detalhe implements DetalheContract
     }
 
     /**
+     * @return string
+     */
+    public function getValorOutrasDespesas()
+    {
+        return $this->valorOutrasDespesas;
+    }
+
+    /**
+     * @param string $valorOutrasDespesas
+     *
+     * @return $this
+     */
+    public function setValorOutrasDespesas($valorOutrasDespesas)
+    {
+        $this->valorOutrasDespesas = $valorOutrasDespesas;
+
+        return $this;
+    }
+
+    /**
      * @return PessoaContract
      */
     public function getPagador()
@@ -582,7 +607,7 @@ class Detalhe implements DetalheContract
 
         return $this;
     }
-    
+
      /**
   * @return string
   */

--- a/src/Cnab/Retorno/Cnab400/Banco/Banrisul.php
+++ b/src/Cnab/Retorno/Cnab400/Banco/Banrisul.php
@@ -196,6 +196,7 @@ class Banrisul extends AbstractRetorno implements RetornoCnab400
             ->setDataCredito($this->rem(296, 301, $detalhe))
             ->setValor(Util::nFloat($this->rem(153, 165, $detalhe)/100, 2, false))
             ->setValorTarifa(Util::nFloat($this->rem(176, 188, $detalhe)/100, 2, false))
+            ->setValorOutrasDespesas(Util::nFloat($this->rem(189, 201, $detalhe), 2, false) / 100 )
             ->setValorDesconto(Util::nFloat($this->rem(241, 253, $detalhe)/100, 2, false))
             ->setValorRecebido(Util::nFloat($this->rem(254, 266, $detalhe)/100, 2, false))
             ->setValorMora(Util::nFloat($this->rem(267, 279, $detalhe)/100, 2, false))

--- a/src/Cnab/Retorno/Cnab400/Banco/Bb.php
+++ b/src/Cnab/Retorno/Cnab400/Banco/Bb.php
@@ -218,6 +218,7 @@ class Bb extends AbstractRetorno implements RetornoCnab400
             ->setDataCredito($this->rem(176, 181, $detalhe))
             ->setValor(Util::nFloat($this->rem(153, 165, $detalhe)/100, 2, false))
             ->setValorTarifa(Util::nFloat($this->rem(182, 188, $detalhe)/100, 2, false))
+            ->setValorOutrasDespesas(Util::nFloat($this->rem(189, 201, $detalhe), 2, false) / 100 )
             ->setValorIOF(Util::nFloat($this->rem(215, 227, $detalhe)/100, 2, false))
             ->setValorAbatimento(Util::nFloat($this->rem(228, 240, $detalhe)/100, 2, false))
             ->setValorDesconto(Util::nFloat($this->rem(241, 253, $detalhe)/100, 2, false))

--- a/src/Cnab/Retorno/Cnab400/Banco/Santander.php
+++ b/src/Cnab/Retorno/Cnab400/Banco/Santander.php
@@ -297,6 +297,7 @@ class Santander extends AbstractRetorno implements RetornoCnab400
             ->setDataCredito($this->rem(296, 301, $detalhe))
             ->setValor(Util::nFloat($this->rem(153, 165, $detalhe)/100, 2, false))
             ->setValorTarifa(Util::nFloat($this->rem(176, 188, $detalhe)/100, 2, false))
+            ->setValorOutrasDespesas(Util::nFloat($this->rem(189, 201, $detalhe), 2, false) / 100 )
             ->setValorIOF(Util::nFloat($this->rem(215, 227, $detalhe)/100, 2, false))
             ->setValorAbatimento(Util::nFloat($this->rem(228, 240, $detalhe)/100, 2, false))
             ->setValorDesconto(Util::nFloat($this->rem(241, 253, $detalhe)/100, 2, false))

--- a/src/Cnab/Retorno/Cnab400/Banco/Sicredi.php
+++ b/src/Cnab/Retorno/Cnab400/Banco/Sicredi.php
@@ -258,6 +258,7 @@ class Sicredi extends AbstractRetorno implements RetornoCnab400
             ->setDataVencimento($this->rem(147, 152, $detalhe))
             ->setValor(Util::nFloat($this->rem(153, 165, $detalhe), 2, false) / 100)
             ->setValorTarifa(Util::nFloat($this->rem(176, 188, $detalhe), 2, false) / 100)
+            ->setValorOutrasDespesas(Util::nFloat($this->rem(189, 201, $detalhe), 2, false) / 100 )
             ->setValorAbatimento(Util::nFloat($this->rem(228, 240, $detalhe), 2, false) / 100)
             ->setValorDesconto(Util::nFloat($this->rem(241, 253, $detalhe), 2, false) / 100)
             ->setValorRecebido(Util::nFloat($this->rem(254, 266, $detalhe), 2, false) / 100)

--- a/src/Cnab/Retorno/Cnab400/Detalhe.php
+++ b/src/Cnab/Retorno/Cnab400/Detalhe.php
@@ -65,6 +65,10 @@ class Detalhe implements DetalheContract
     /**
      * @var string
      */
+    protected $valorOutrasDespesas;
+    /**
+     * @var string
+     */
     protected $valorIOF;
     /**
      * @var string
@@ -404,6 +408,26 @@ class Detalhe implements DetalheContract
     public function setValorTarifa($valorTarifa)
     {
         $this->valorTarifa = $valorTarifa;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValorOutrasDespesas()
+    {
+        return $this->valorOutrasDespesas;
+    }
+
+    /**
+     * @param string $valorOutrasDespesas
+     *
+     * @return Detalhe
+     */
+    public function setValorOutrasDespesas($valorOutrasDespesas)
+    {
+        $this->valorOutrasDespesas = $valorOutrasDespesas;
 
         return $this;
     }


### PR DESCRIPTION
=> leitura retornos: cria campo para valorOutrasDespesas e passa a considerá-lo já implementados nos retornos de layout CNAB400 de Banrisul,BB,Santander e Sicredi;
![image](https://user-images.githubusercontent.com/22413553/124321044-62208900-db53-11eb-8fdb-cd5181c3dfcd.png)


=> retorno Sicredi CNAB400 ocorrência '28 - Tarifas': ao retornar detalhes de Tarifas com Motivos da ocorrência(posições 319 a 328), os mesmos estavam sendo considerados como erro, e as mensagens para tradução desses motivos eram pegas da lista geral de rejeições, no entanto sempre quando vier corrência do tipo '28-Tarifas' os motivos de ocorrências devem ser buscados em uma lista específica, de acordo com o manual:

![image](https://user-images.githubusercontent.com/22413553/124320667-a7908680-db52-11eb-8ac7-9bf9151bb618.png)
