### PR TITLE
Correção da posição da paginação nos arquivos PDF do boleto

### DIFF
--- a/src/Boleto/Render/AbstractPdf.php
+++ b/src/Boleto/Render/AbstractPdf.php
@@ -19,7 +19,7 @@ abstract class AbstractPdf extends \FPDF
 
     public function Footer()
     {
-        $this->SetY(-20);
+        $this->SetY(-8);
         if (count($this->PageGroups)) {
             $this->Cell(0, 6, 'Boleto '.$this->GroupPageNo().'/'.$this->PageGroupAlias(), 0, 0, 'C');
         }


### PR DESCRIPTION
O indicador de paginação está sendo sobreposto pelo código de barras nos arquivos  PDF do boleto.
Essa contribuição corrige isso.

^_^
