### PR TITLE
Erro na função hasError dos retornos

### DIFF
--- a/src/Cnab/Retorno/Cnab240/Detalhe.php
+++ b/src/Cnab/Retorno/Cnab240/Detalhe.php
@@ -592,7 +592,7 @@ class Detalhe implements DetalheContract
      */
     public function hasError()
     {
-        return $this->getOcorrencia() == self::OCORRENCIA_ERRO;
+        return $this->getOcorrenciaTipo() == self::OCORRENCIA_ERRO;
     }
 
     /**

--- a/src/Cnab/Retorno/Cnab400/Detalhe.php
+++ b/src/Cnab/Retorno/Cnab400/Detalhe.php
@@ -562,7 +562,7 @@ class Detalhe implements DetalheContract
      */
     public function hasError()
     {
-        return $this->getOcorrencia() == self::OCORRENCIA_ERRO;
+        return $this->getOcorrenciaTipo() == self::OCORRENCIA_ERRO;
     }
 
     /**


### PR DESCRIPTION
Alterado para usar getOcorrenciaTipo() ao invés de getOcorrencia() pois
estava utilizando o código do arquivo como referência ao invés do código
interno.

Ex: Ocorrencia de baixa do itaú "09" estava considerando como erro pois
é o código interno de erro "OCORRENCIA_ERRO"