### PR TITLE
Adaptando codigo para beneficiario caixa economica - 7 digitos

### DIFF
--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -58,6 +58,8 @@ abstract class AbstractBoleto implements BoletoContract
      * @var float
      */
     protected $desconto;
+    protected $desconto2;
+    protected $desconto3;
     /**
      * Valor para multa
      *
@@ -112,6 +114,8 @@ abstract class AbstractBoleto implements BoletoContract
      * @var \Carbon\Carbon
      */
     protected $dataDesconto;
+    protected $dataDesconto2;
+    protected $dataDesconto3;
     /**
      * Campo de aceite
      *
@@ -333,6 +337,12 @@ abstract class AbstractBoleto implements BoletoContract
         // Marca a data de desconto
         if (!$this->getDataDesconto()) {
             $this->setDataDesconto($this->getDataVencimento());
+        }
+        if (!$this->getDataDesconto2()) {
+            $this->setDataDesconto($this->getDataVencimento2());
+        }
+        if (!$this->getDataDesconto3()) {
+            $this->setDataDesconto($this->getDataVencimento3());
         }
     }
 
@@ -579,6 +589,18 @@ abstract class AbstractBoleto implements BoletoContract
 
         return $this;
     }
+    public function setDataDesconto2(Carbon $dataDesconto)
+    {
+        $this->dataDesconto2 = $dataDesconto;
+
+        return $this;
+    }
+    public function setDataDesconto3(Carbon $dataDesconto)
+    {
+        $this->dataDesconto3 = $dataDesconto;
+
+        return $this;
+    }
 
     /**
      * Retorna a data de limite de desconto
@@ -588,6 +610,14 @@ abstract class AbstractBoleto implements BoletoContract
     public function getDataDesconto()
     {
         return $this->dataDesconto;
+    }
+    public function getDataDesconto2()
+    {
+        return $this->dataDesconto2;
+    }
+    public function getDataDesconto3()
+    {
+        return $this->dataDesconto3;
     }
 
     /**
@@ -1070,6 +1100,18 @@ abstract class AbstractBoleto implements BoletoContract
 
         return $this;
     }
+    public function setDesconto2($desconto)
+    {
+        $this->desconto2 = Util::nFloat($desconto, 2, false);
+
+        return $this;
+    }
+    public function setDesconto3($desconto)
+    {
+        $this->desconto3 = Util::nFloat($desconto, 2, false);
+
+        return $this;
+    }
 
     /**
      * Retorna o desconto total do boleto (incluindo taxas)
@@ -1079,6 +1121,14 @@ abstract class AbstractBoleto implements BoletoContract
     public function getDesconto()
     {
         return Util::nFloat($this->desconto, 2, false);
+    }
+    public function getDesconto2()
+    {
+        return Util::nFloat($this->desconto2, 2, false);
+    }
+    public function getDesconto3()
+    {
+        return Util::nFloat($this->desconto3, 2, false);
     }
 
     /**
@@ -1631,8 +1681,12 @@ abstract class AbstractBoleto implements BoletoContract
                 'data_processamento' => $this->getDataProcessamento(),
                 'data_documento' => $this->getDataDocumento(),
                 'data_desconto' => $this->getDataDesconto(),
+                'data_desconto2' => $this->getDataDesconto2(),
+                'data_desconto3' => $this->getDataDesconto3(),
                 'valor' => Util::nReal($this->getValor(), 2, false),
                 'desconto' => Util::nReal($this->getDesconto(), 2, false),
+                'desconto2' => Util::nReal($this->getDesconto2(), 2, false),
+                'desconto3' => Util::nReal($this->getDesconto3(), 2, false),
                 'multa' => Util::nReal($this->getMulta(), 2, false),
                 'juros' => Util::nReal($this->getJuros(), 2, false),
                 'juros_apos' => $this->getJurosApos(),

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -221,7 +221,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(154, 154, '0');
         $this->add(155, 169, '000000000000000');
         $this->add(170, 209, '');
-        $this->add(210, 212, '000');
+        $this->add(210, 212, '');
         $this->add(213, 232, '');
         $this->add(233, 240, '');
 
@@ -256,13 +256,13 @@ class Caixa extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_ALTERACAO) {
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
-        $this->add(18, 18, '0');
-        $this->add(19, 26, '00000000');
-        $this->add(27, 41, '000000000000000');
-        $this->add(42, 42, '0');
-        $this->add(43, 50, '00000000');
-        $this->add(51, 65, '000000000000000');
-        $this->add(66, 66, $boleto->getMulta() > 0 ? '2' : '0'); //0 = ISENTO | 1 = VALOR FIXO | 2 = PERCENTUAL
+        $this->add(18, 18, $boleto->getDesconto2() > 0 ? '1' : '0');
+        $this->add(19, 26, $boleto->getDesconto2() > 0 ? $boleto->getDataDesconto2()->format('dmY') : '00000000');
+        $this->add(27, 41, Util::formatCnab('9', $boleto->getDesconto2(), 15, 2));
+        $this->add(42, 42, $boleto->getDesconto3() > 0 ? '1' : '0');
+        $this->add(43, 50, $boleto->getDesconto3() > 0 ? $boleto->getDataDesconto3()->format('dmY') : '00000000');
+        $this->add(51, 65, Util::formatCnab('9', $boleto->getDesconto3(), 15, 2));
+        $this->add(66, 66, $boleto->getMulta() > 0 ? '1' : '0'); //0 = ISENTO | 1 = VALOR FIXO | 2 = PERCENTUAL
         $this->add(67, 74, $boleto->getDataVencimento()->format('dmY'));
         $this->add(75, 89, Util::formatCnab('9', $boleto->getMulta(), 15, 2));  //2,20 = 0000000000220
         $this->add(90, 240, '');
@@ -299,7 +299,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(144, 151, $this->getDataRemessa('dmY'));
         $this->add(152, 157, date('His'));
         $this->add(158, 163, Util::formatCnab('9', $this->getIdremessa(), 6));
-        $this->add(164, 166, '101');
+        $this->add(164, 166, '107');
         $this->add(167, 171, '00000');
         $this->add(172, 191, '');
         $this->add(192, 211, Util::formatCnab('X','REMESSA-PRODUCAO', 20));
@@ -325,7 +325,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(9, 9, 'R');
         $this->add(10, 11, '01');
         $this->add(12, 13, '00');
-        $this->add(14, 16, '060');
+        $this->add(14, 16, '067');
         $this->add(17, 17, '');
         $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
         $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
@@ -333,12 +333,8 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(41, 53, Util::formatCnab('9', 0, 13));
         $this->add(54, 58, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(59, 59, CalculoDV::cefAgencia($this->getAgencia()));
-        if(strlen($this->getCodigoCliente()) == 7) {
-            $this->add(60, 65, '000000');
-        } else {
-            $this->add(60, 65, Util::formatCnab('9', Util::onlyNumbers($this->getCodigoCliente()), 6));
-        }
-        $this->add(66, 72, '0000000');
+        $this->add(60, 66, Util::formatCnab('9', Util::onlyNumbers($this->getCodigoCliente()), 7));
+        $this->add(67, 72, '000000');
         $this->add(73, 73, '0');
         $this->add(74, 103, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(104, 183, '');


### PR DESCRIPTION
ADAPTAÇÃO PARA CEDENTE COM QUANTIDADE DE CARACTERES DE 7 DÍGITOS

Alteração no segmento Q
20.3Q | 210 - 212 | Preenchido com ' '

Alteração no segmento R
08.3R, 09.3R, 10.3R | 18 - 18, 19 - 26, 26 - 41 | Preenchimento de desconto 2
11.3R, 12.3R, 13.3R | 42 - 42, 43 - 50, 51 - 65 | Preenchimento do desconto 3

Alteração no Header (Lote 0)
20.0 | 164 - 166 | Alterado para versão 107, Aplica-se para clientes com códigos de beneficiário composto por até 7 dígitos

Alteração no Header (Lote 1)
07.1 | 14 - 16 | Alterado para versão 067, Aplica-se para clientes com códigos de beneficiário composto por até 7 dígitos

Demais alterações referente ao código do beneficiário para conter '7' dígitos. Caso o código possua a quantidade de caracteres menores que '7', adicione '0' à esquerda até preencher '7' casas.
 
Ex.: 0099999.