### PR TITLE
correçao if ternario do campo Mora / Multa / Juros

### DIFF
--- a/src/Boleto/Render/Pdf.php
+++ b/src/Boleto/Render/Pdf.php
@@ -315,7 +315,7 @@ class Pdf extends AbstractPdf implements PdfContract
         $this->Cell(50, $this->cell, $this->_(''), 'R', 1);
 
         $this->Cell(120, $this->desc, $this->_(''), 'LR');
-        $this->Cell(50, $this->desc, $this->_('(+) Mora / Multa' . ($this->boleto[$i]->getCodigoBanco() == '104') ? ' / Juros' : ''), 'TR', 1);
+        $this->Cell(50, $this->desc, $this->_('(+) Mora / Multa' . ($this->boleto[$i]->getCodigoBanco() == '104' ? ' / Juros' : '')), 'TR', 1);
 
         $this->Cell(120, $this->cell, $this->_(''), 'LR');
         $this->Cell(50, $this->cell, $this->_(''), 'R', 1);


### PR DESCRIPTION
Percebi que no campo referente à "(+) Mora / Multa" estava indo apenas " / Juros", sendo que pelo que entendi da lógica a ideia seria exibir sempre "(+) Mora / Multa" e concatenar com " / Juros " se o banco for 104 e com vazio se não. Então ajustei os parenteses do if ternário para sempre exibir "(+) Mora / Multa" e concatenar com " / Juros " apenas se o banco for 104.

Estava indo:

![image](https://user-images.githubusercontent.com/30847132/151419623-4c6c8b96-c391-4551-91e0-00391270feb6.png)

Agora está indo (no caso de banco do brasil):

![image](https://user-images.githubusercontent.com/30847132/151419695-5607333a-d18a-4156-9d67-3387012f91bc.png)


