### PR TITLE
Ao gerar data início cobrança de juros está alterando o valor original data de vencimento (CNAB_240 - Caixa)

### DIFF
--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -655,7 +655,7 @@ abstract class AbstractBoleto implements BoletoContract
      */
     public function getDataVencimentoApos()
     {
-        return $this->getDataVencimento()->addDays((int) $this->getJurosApos());
+        return $this->getDataVencimento()->copy()->addDays((int) $this->getJurosApos());
     }
 
     /**

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -159,7 +159,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(109, 109, Util::formatCnab('9', $boleto->getAceite(), 1));
         $this->add(110, 117, $boleto->getDataDocumento()->format('dmY'));
         $this->add(118, 118, $boleto->getJuros() ? '2' : '3'); //'2' = Percentual Mensal '3' = Isento
-        $this->add(119, 126, $boleto->getDataVencimento()->addDays(1)->format('dmY'));
+        $this->add(119, 126, $boleto->getDataVencimento()->copy()->addDays($boleto->getJurosApos() === false ? 1 : (int)$boleto->getJurosApos())->format('dmY'));
         $this->add(127, 141, Util::formatCnab('9', $boleto->getJuros(), 15, 2)); //Taxa mensal
         $this->add(142, 142, $boleto->getDesconto() > 0 ? '1' : '0'); // 0 = Sem Desconto, 1 = Valor Fixo até a data informada, 2 = Percentual até a data informada
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');


### PR DESCRIPTION
Ao gerar arquivo de remessa Caixa (CNAB_240) e logo na sequência gerar a impressão do boleto, notou-se que estava gerando a impressão do boleto com o vencimento um dia após a data de vencimento que consta no arquivo remessa. Para ajustar foi alterado para adicionar dias em uma cópia da instância do Carbon.