### PR TITLE
Setar código de barras caso existir

### DIFF
--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -1400,6 +1400,20 @@ abstract class AbstractBoleto implements BoletoContract
     }
 
     /**
+     * Define um código de barras caso existir
+     *
+     * @param  string $campoCodigoBarras
+     *
+     * @return AbstractBoleto
+     */
+    
+    public function setCampoCodigoBarras($campoCodigoBarras){
+        $this->campoCodigoBarras = $campoCodigoBarras;
+        return $this;
+    }
+
+
+    /**
      * Retorna o logotipo do banco em Base64, pronto para ser inserido na página
      *
      * @return string


### PR DESCRIPTION
Não sei se é pertinente para todos os casos, mas no banco inter (boleto via api) seria interessante poder setar o código de barras para gerar o PDF do boleto.
