### PR TITLE
feat: adiciona o qrcode do pix aos boletos

### DIFF
--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -343,6 +343,14 @@ abstract class AbstractBoleto implements BoletoContract
     public $valorRecebido;
 
     /**
+     *
+     * Recebe a imagem em base 64 do QR Code do PIX
+     *
+     * @var ?string
+     */
+    private $pixQrCode = null;
+
+    /**
      * AbstractBoleto constructor.
      *
      * @param array $params
@@ -1665,6 +1673,22 @@ abstract class AbstractBoleto implements BoletoContract
     }
 
     /**
+     * @return ?string
+     */
+    public function getPixQrCode(): ?string
+    {
+        return $this->pixQrCode;
+    }
+
+    /**
+     * @param string $pixQrCode
+     */
+    public function setPixQrCode(string $pixQrCode): void
+    {
+        $this->pixQrCode = $pixQrCode;
+    }
+
+    /**
      * @param $situacao
      *
      * @return bool
@@ -1868,7 +1892,8 @@ abstract class AbstractBoleto implements BoletoContract
                 'carteira_nome' => $this->getCarteiraNome(),
                 'uso_banco' => $this->getUsoBanco(),
                 'status' => $this->getStatus(),
-                'mostrar_endereco_ficha_compensacao' => $this->getMostrarEnderecoFichaCompensacao()
+                'mostrar_endereco_ficha_compensacao' => $this->getMostrarEnderecoFichaCompensacao(),
+                'pix_qrcode' => $this->getPixQrCode(),
             ], $this->variaveis_adicionais
         );
     }

--- a/src/Boleto/Render/Pdf.php
+++ b/src/Boleto/Render/Pdf.php
@@ -93,6 +93,7 @@ class Pdf extends AbstractPdf implements PdfContract
             $this->SetFont($this->PadraoFont, '', $this->fcel);
         }
 
+
         $this->traco('Recibo do Pagador', 4);
         return $this;
     }
@@ -363,6 +364,19 @@ class Pdf extends AbstractPdf implements PdfContract
 
             $this->SetXY($xOriginal, $yOriginal);
         }
+
+        if ($this->boleto[$i]->getPixQrCode() !== null){
+            $img = explode(',',$this->boleto[$i]->getPixQrCode(),2)[1];
+            $pic = 'data://text/plain;base64,'. $img;
+
+            $this->SetXY(112, 216);
+            $this->SetFont($this->PadraoFont, '', 6);
+            $this->Cell(60, $this->cell, "Pague via PIX", "", "", "L");
+            $this->Image($pic, 110,220,20,20,'png');
+
+            $this->SetXY($xOriginal, $yOriginal);
+        }
+
         return $this;
     }
 

--- a/src/Boleto/Render/view/partials/ficha-compensacao.blade.php
+++ b/src/Boleto/Render/view/partials/ficha-compensacao.blade.php
@@ -95,16 +95,22 @@
         </td>
     </tr>
     <tr>
-        <td colspan="7">
+        <td colspan="{{ isset($pix_qrcode) ? 6 : 7 }}">
             <div class="titulo">Instruções de responsabilidade do beneficiário. Qualquer dúvida sobre este boleto, contate o beneficiário</div>
         </td>
+        @if(isset($pix_qrcode))
+            <td colspan="1" rowspan="5">
+                <p class="titulo" style="text-align: center">Pague via PIX</p>
+                <img src="{{ $pix_qrcode }}" style="height: 100%; width: 100%;">
+            </td>
+        @endif
         <td>
             <div class="titulo">(-) Descontos / Abatimentos</div>
             <div class="conteudo rtl"></div>
         </td>
     </tr>
     <tr>
-        <td colspan="7" class="notopborder">
+        <td colspan="{{ isset($pix_qrcode) ? 6 : 7 }}" class="notopborder">
             <div class="conteudo">{{ $instrucoes[0] }}</div>
             <div class="conteudo">{{ $instrucoes[1] }}</div>
         </td>
@@ -114,7 +120,7 @@
         </td>
     </tr>
     <tr>
-        <td colspan="7" class="notopborder">
+        <td colspan="{{ isset($pix_qrcode) ? 6 : 7 }}" class="notopborder">
             <div class="conteudo">{{ $instrucoes[2] }}</div>
             <div class="conteudo">{{ $instrucoes[3] }}</div>
         </td>
@@ -124,7 +130,7 @@
         </td>
     </tr>
     <tr>
-        <td colspan="7" class="notopborder">
+        <td colspan="{{ isset($pix_qrcode) ? 6 : 7 }}" class="notopborder">
             <div class="conteudo">{{ $instrucoes[4] }}</div>
             <div class="conteudo">{{ $instrucoes[5] }}</div>
         </td>
@@ -134,7 +140,7 @@
         </td>
     </tr>
     <tr>
-        <td colspan="7" class="notopborder">
+        <td colspan="{{ isset($pix_qrcode) ? 6 : 7 }}" class="notopborder">
             <div class="conteudo">{{ $instrucoes[6] }}</div>
             <div class="conteudo">{{ $instrucoes[7] }}</div>
         </td>

--- a/tests/Boleto/BoletoTest.php
+++ b/tests/Boleto/BoletoTest.php
@@ -483,4 +483,34 @@ class BoletoTest extends TestCase
         $this->assertNotNull($boleto->renderHTML());
         $this->assertNotNull($boleto->renderPDF());
     }
+
+    public function testBoletoBBWithQRCodePix()
+    {
+        $boleto = new Boleto\Bb(
+            [
+                'logo' => realpath(__DIR__ . '/../../logos/') . DIRECTORY_SEPARATOR. '001.png',
+                'dataVencimento' => new \Carbon\Carbon(),
+                'valor' => 100,
+                'multa' => false,
+                'juros' => false,
+                'numero' => 1,
+                'numeroDocumento' => 1,
+                'pagador' => self::$pagador,
+                'beneficiario' => self::$beneficiario,
+                'carteira' => 11,
+                'convenio' => 1234567,
+                'descricaoDemonstrativo' => ['demonstrativo 1', 'demonstrativo 2', 'demonstrativo 3'],
+                'instrucoes' =>  ['instrucao 1', 'instrucao 2', 'instrucao 3'],
+                'aceite' => 'S',
+                'especieDoc' => 'DM',
+                'pix_qrcode' => "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAAEsCAYAAAB5fY51AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAABmJLR0QAAAAAAAD5Q7t/AAAACXBIWXMAAABgAAAAYADwa0LPAAAObElEQVR42u3dQU7jTBPG8SbhFKC5QGaHwMNxUA4WcZzEQrMicwAWcwoHf4tRRswb+OJyXK567P9P8g417XbnmUzSRV21bdsWABCwiJ4AAHRFYAGQQWABkEFgAZBBYAGQQWABkEFgAZBBYAGQQWABkEFgAZBBYAGQQWABkEFgAZBBYAGQQWABkEFgAZBBYAGQQWABkEFgAZBBYAGQQWABkEFgAZBBYAGQQWABkEFgAZBBYAGQQWABkEFgAZBBYAGQQWABkEFgAZBBYAGQQWABkJEmsG5vb8vV1RWX4cpgv9+Xh4eHslwuR7335XJZfvz4Ufb7PftsBvvsKE1gQdPT01N5eXkp7+/vo/7e9/f3Utd1Wa/X0UuAERFYuMjPnz9Df//Ly0v0EmBEBBYuMvY7q2y/H+MisADIILAAyCCwAMggsADIILDQ2+FwiJ4CZobAQm8cKcDYrqMnAD2Hw6G8vLxwaBOjk3yH9fb2Vtq2neR1c3PjsmZDltBcX1+Xx8fH8uvXL9McVqtVqeu6NE3z6b03TVO2221ZrVbRW6yUwj7LSDKwYBdVQvPR8/Pz39D8zLE+cLPZhM0RuRFYMxFdQlNKKXd3d51+7v7+PnqqSIrAmokMJSxfvbPq+3OYHwILgAwCC4AMAguADAILgAwCayYWi/hH3bWUh5IffCV+F2MUGY4KdC3loeQHXyGwZmKz2ZSqqkLfaa3X67Lb7b58B3U4HMput6PkB1+afC1hhq4fbdtGT6F8//697Ha7Qcb6WEtoKc/59etXeXx8jF4KF+yzcfAOC2aU0CAKgYXeMnwuhnkhsNAbJTQYG4EFQAaBBUAGgQVABoEFQAaBhYtkKPnBfLDbcBGONmBMBBYukqHkB/PBLpuJIbvmHE+67/f7vyU/h8Ph4k4u2brmIB8CayaG7Jrz/v5e6roevEiZkh+cQ2DNhEfXHK8/A8PnYvgKgTUTHl1zvDrxUPKDrxBYAGQQWABkEFgAZBBYAGQQWDPBwU5MAbt4JjgqgCkgsGaCEhpMAbt3Js6V0FAWAwUEFkoplMVAA4GFf/BZFzIjsPAPymKQGYEFQAaBBUAGgQVABoEFQAaBhRNdD5d6HkLNMAfkw9PGia5HGzyPQGSYA/IhsHDiXBnPYrEoVVW5HjLNMAfkcx09AW9t20ZPIYX9fl+enp7Kz58/P/3TxovFotzf35fNZvO3jGeKc/DCPhsH77Bm4lzXHK9OONnmAG0E1kx07Zrj1QknyxygjcCaia4dbrw64WSZA7QRWABkEFgAZBBYAGQQWABkEFgYDeU2uBQ7A6Oh3AaXIrAwGsptcLE2iZubm7aUwmW4LLzGfX19be/v79vFYvHpWIvFoq2qqn19fU0xLvvMd595SzMbNpJmYN3f33cas6qqFOOyz7QD66ptc1Rt3t7elt+/f0dPQ4rl0V1dXbmMu1wuO51MXywW5XA4hI/LPrNLEhGlFD7DwoW8ym0o48FnCCwAMggsADIILAAyCCwAMgismfAqi1EbF9p42jPhVRajNi7ERR8EO+JAn++BvtfX17aqKpcT6Urjss84OIqJsXa3AcZCYOHEw8NDp0YQVVVJteKCPgILJ7zKYoBLEVg44VV3CFyKbwkByCCwAMggsADIILAAyCCwcIKyGGTFjsMJymKQFYGFE3S3QVrRtUFH57qkqF1e3WKyzXfIe8vWYYdx80kTWF27pKhdXt1isszX496ydNhh3HzSnHTvWg6ixqtbTJb5Wqh12GHcfNIElqUcRI1liTOsg9eW8Cr5YVzfcTPhQ3cAMggsADIILAAyCCwAMgisZKZa7mL9Vqrrz6t+28U69DPNV4ewqZa7dPmTy31+3jquGtbhP6IPgh2VBIc8vS6Lc91iss33nKZp2u12265WK9McVqtVu91u26ZpBh3Xa096jZthHTJJM3PrQ6zrevCHqBAAFmNsZrWSKq896TVuhnXIRPLgaF3X5eHh4ezP7Xa78vj4GH1r4Yf0rOtgmW/XDjtZWO4twwHPDOuQiWRgNU1Tlsvl2Z87HA7l+vo6+tbCN4d1HSzzjS4lsiKw7PPNRPJD9y5hZfm5qfNcB6Wwgj7JwAIwTwQWABkEFgAZBBYAGWkCy6tTS3SpS/Tvt85DbX1hp/zM0szcq1NLdKlL9O+3zkNtfWEn/cyiT64enStJueQP80eUumT7g/9TW9++l0WGcae8J/tIE1hRLql1+3/lQR8NWb6i3N3G61lkCBavcaP2ZNZwm31gHW23W9PmqOu689genXAUu9t4PYsMweI1bvSezNZhJ01pTjRr+UrX8qBSfMpXFLvbdOVZUmXZ7mqlOR57MluHHQLrA7UN6vXoMnRfybBmU94PGZ5xH2m+JQSAcwgsADIILAAyCCwAMgisD5TKV7KUV3h9S+jBc83Uutt47XX3eUdPIBOl8pUs5RUefx7Z608ue66ZWncbr73uLvogWCYK5StjnEC2zOdcVxcLr5PufddsyHXIdorfa697kwysDKUuqqUNXXi9oLwuS0nKlNdhDiQPjnp0aqmqqux2u8HnYB03gwxNEiy6dlGa+joIvpTNJAMrQ6mLamlDF2ovVEtJypTXQfClbCYZWJQ2+OKFyjpkxbeEAGQQWABkEFgAZBBYAGRIBlaGUhfV0oapzhnzILkzM5S6yJY2THTOmAfJwNpsNqWqqkHeCSwWi1JVVdlsNoPOoe+4GQy5vsCgoo/aZ5Kh3CZD2VGUvvV2XixzGLI8KNs6ZDKPu+woQycRtQ47Hqxdc7xY5mDpWKO2DplInnT3kqHcJkPZUTRr1xyvLWw56e5RHpRlHTIhsD7IUG6ToewoA7VnMeU5ZMKnqgBkEFgAZBBYAGQQWABkEFgfZCi3yVB2pCa6y47X+ip9szuWae9kowzlNhnKjtREd9nxWt8sHXZSiT4IlkmGTiJqHXa8WO5zyM49lmfhtb6cdP/aPO4Sg5b8jBGaGeag9izmgIOjM+HRacjC2j3I4wBtlg5GXs9iDi9lAmsmPEp+LKzlQR6BlaVEyetZzOGlTGDNRIYOMJatNuUSpSnfmze+JQQgg8ACIIPAAiCDwAIgg8DCaCzf0E25RGnK9+ZtHneJFCxnj6ZcojTle/NGYGE06/W67Ha7Tu+0MnRG8jLle3MXfdT+6ObmZtSSkSlcFpZxz3WA6Vvrdu7KVkKjJkPXJ28ElvBletCGcbt2gLF2del6qXX5ySJD1ydvaU66397elt+/f0dPQ4rl0Xl0gLF2dekqSwmNmgxdn7zxGRZOdG1XNXRbq6PImkdlXddNeX0JLAAyCCwAMggsADIILAAyCKyZ8OoAQ5lJHtFdfka5x+gJYBxeHWAoM8kjusvPKKIPgh1xcNT34KhXBxi6/OSRoeuTN8nAent7i55uinWAXVT3IK/rkn9oFMt4JE+6v729lW/fvkVPOXwdkjw6KdHdg7xYOwJ1XYcsnYaOCKxkCCxf0d2DvFjLbVTLePjQHbMyxbDqc1+qZTwEFgAZBBYAGQQWABkEFgAZBBZmRbksBQQWZka6LAUEFuZlyI41GN/kn9rV1VX4lcF+vy8PDw9luVx+Osflcll+/PhR9vv9oONaLq85fBz3+/fvf1uNtX9K00a5mqYp2+22rFar6K2gLbo26MirlrDrmJ6X1zpYeHVU6Tqu5fKaQ4ZuMV6dhqz7wWtcb5MvzcnwDseyxF6lOV6lGB6lLlMuM/HqNFSKbT9YXhdJIqKUMoP/EuIPr1IMj9KNKZeZeHUamgsCC4AMAguADAILgAwCC4AMAgsXie6aE/2tXyaWtVDtsJNrNpAT3TVnin/uuC/LWqh22CGwcJEhS10Wi0WpqqpsNpuzP3s4HMputyvr9Tp6CdJYr9d/T/Gfc+65WZ7FqKJPrh5x0t2+DhZe8/Xi1d1myDn07SwTtQ+zdsIxrV30BI4ILPs6WKgFlkfJj/XevEp+ovdjhhKlvijNGYFlib1Kc9RKMby621juzavkJ3pPZihR6j336AkAn8lQRqNU8uNxXxkRWABkEFgAZBBYAGQQWABkEFg4ofoN0tBUy1emNt9/5h49AeRDucsfquUrU5vvRwQWTlhKPKZMtnzlC2rz/VT0ydUjTrrb18Ei6t6zla9kYJnvarVq67pum6aJnnYKvMOCq/f391LXNUXKPT0/P/9tYQb+S4iR8LlYP3d3d9FTSIXAwiiUy0Ei8c7qXwQWABkEFgAZBBYAGQQWABkEFkaRoRwkwxws88gy30xYEYwiQzlIhjlY5pFlvpkQWHCVoRwkwxw+mlrJz6iij9ofeZXmqMlQmpOhHMRrvl6dcKLG9bqydtghsJLJEFh1XUcvg9t8vTrhRI/rdWXrsDP5rjlqMnTNaZom/IS113y9OuFEj+slW4cdPsPCieiw8pyvVyec6HG9RP/+/yKwAMggsADIILAAyCCwAMggsDArXmUx0eN6if79J/OJngAwJq+ymOhxvUT//v8isDArXmUxUeN6SVseFH1y9chywpvL96S7hVdJitd8MxhyzZqmabfbbbtardzKmTJJ87QJLM3A8ipJmXJgeazZdrs1rVmG8qs+JEtz8Ifl0VlKXSzjepWkeM03A481OxwO5fr6uvMcMpRf9cFnWLiIV0nKlHmsmTV8FMOqFAILgBACC4AMAguADAILgAwCayaiS0eyjJsBa9af7sxhEl06kmXcDFizC0QfBDvi4KjvwdHX19e2qiqXJglK42bAmvWX5uAoAJzDfwkByCCwAMggsADIILAAyCCwAMggsADIILAAyCCwAMggsADIILAAyCCwAMggsADIILAAyCCwAMggsADIILAAyCCwAMggsADIILAAyCCwAMggsADIILAAyCCwAMggsADIILAAyCCwAMggsADIILAAyCCwAMggsADIILAAyCCwAMggsADIILAAyPgfua4A7AeOtswAAAAldEVYdGRhdGU6Y3JlYXRlADIwMjItMDktMDZUMDE6MzM6MDErMDA6MDCmKlR4AAAAJXRFWHRkYXRlOm1vZGlmeQAyMDIyLTA5LTA2VDAxOjMzOjAxKzAwOjAw13fsxAAAAABJRU5ErkJggg=="
+            ]
+        );
+
+        $boletoHtml = $boleto->renderHTML();
+
+        $this->assertIsArray($boleto->toArray());
+        $this->assertNotNull($boletoHtml);
+        $this->assertNotNull($boleto->renderPDF());
+    }
 }


### PR DESCRIPTION
Alguns bancos já fornecem via API, quando gerado o boleto, o código PIX para pagamento, esta funcionalidade permite adicionar a imagem do QrCode do Pix em base 64 no corpo do boleto.


## Como usar

```php
$boleto = new Eduardokum\LaravelBoleto\Boleto\Banco\Bb(
    [
        'logo'                   => realpath(__DIR__ . '/../logos/') . DIRECTORY_SEPARATOR . '001.png',
        'dataVencimento'         => new \Carbon\Carbon(),
        'valor'                  => 100,
        'multa'                  => false,
        'juros'                  => false,
        'numero'                 => 1,
        'numeroDocumento'        => 1,
        'descricaoDemonstrativo' => ['demonstrativo 1', 'demonstrativo 2', 'demonstrativo 3'],
        'instrucoes'             => ['Sr. Caixa, não aceitar após o vencimento ou com cheque.', 'instrucao 2', 'instrucao 3'],
        'aceite'                 => 'S',
        'especieDoc'             => 'DM',
        'pagador'                => $pagador,
        'beneficiario'           => $beneficiario,
        'carteira'               => 11,
        'convenio'               => 1234567,
        'pix_qrcode'             => "base64_qrcode_pix",
    ]
);
```
Exemplo do Boleto em PDF do Banco do Brasil
[bb.pdf](https://github.com/eduardokum/laravel-boleto/files/9492769/bb.pdf)

Exemplo do Boleto em HTML do Banco do Brasil
![image](https://user-images.githubusercontent.com/39380116/188532287-942a8d1d-fd22-4d0f-8822-e18f17ba3583.png)
