### PR TITLE
Adicionando número de lote da remessa nos segmentos Header, P, Q e R

### DIFF
--- a/src/Cnab/Remessa/AbstractRemessa.php
+++ b/src/Cnab/Remessa/AbstractRemessa.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Eduardokum\LaravelBoleto\Cnab\Remessa;
 
 use Carbon\Carbon;
@@ -100,6 +101,12 @@ abstract class AbstractRemessa
      */
     protected $agencia;
     /**
+     * Dígito da conta
+     *
+     * @var int
+     */
+    protected $agenciaDv;
+    /**
      * Conta
      *
      * @var int
@@ -154,7 +161,8 @@ abstract class AbstractRemessa
      *
      * @param $data
      */
-    public function setDataRemessa($data){
+    public function setDataRemessa($data)
+    {
         $this->dataRemessa = $data;
     }
 
@@ -165,8 +173,9 @@ abstract class AbstractRemessa
      *
      * @return string;
      */
-    public function getDataRemessa($format){
-        if(is_null($this->dataRemessa)){
+    public function getDataRemessa($format)
+    {
+        if (is_null($this->dataRemessa)) {
             return Carbon::now()->format($format);
         }
         return $this->dataRemessa->format($format);
@@ -196,8 +205,8 @@ abstract class AbstractRemessa
     {
         $args = func_get_args();
         foreach ($args as $arg) {
-            ! is_array($arg) || call_user_func_array([$this, __FUNCTION__], $arg);
-            ! is_string($arg) || array_push($this->camposObrigatorios, $arg);
+            !is_array($arg) || call_user_func_array([$this, __FUNCTION__], $arg);
+            !is_string($arg) || array_push($this->camposObrigatorios, $arg);
         }
 
         return $this;
@@ -279,6 +288,30 @@ abstract class AbstractRemessa
     }
 
     /**
+     * Define a agência
+     *
+     * @param  int $agenciaDv
+     *
+     * @return AbstractRemessa
+     */
+    public function setAgenciaDv($agenciaDv)
+    {
+        $this->agenciaDv = (string) $agenciaDv;
+
+        return $this;
+    }
+
+    /**
+     * Retorna a agência
+     *
+     * @return int
+     */
+    public function getAgenciaDv()
+    {
+        return $this->agenciaDv;
+    }
+
+    /**
      * Define o número da conta
      *
      * @param  int $conta
@@ -311,7 +344,7 @@ abstract class AbstractRemessa
      */
     public function setContaDv($contaDv)
     {
-        $this->contaDv = substr($contaDv, - 1);
+        $this->contaDv = substr($contaDv, -1);
 
         return $this;
     }
@@ -336,7 +369,7 @@ abstract class AbstractRemessa
      */
     public function setCarteira($carteira)
     {
-        if (! in_array($carteira, $this->getCarteiras())) {
+        if (!in_array($carteira, $this->getCarteiras())) {
             throw new \Exception("Carteira não disponível!");
         }
         $this->carteira = $carteira;
@@ -521,11 +554,11 @@ abstract class AbstractRemessa
     public function save($path, $suggestName = false)
     {
         $folder = dirname($path);
-        if (! is_dir($folder)) {
+        if (!is_dir($folder)) {
             mkdir($folder, 0777, true);
         }
 
-        if (! is_writable(dirname($path))) {
+        if (!is_writable(dirname($path))) {
             throw new \Exception('Path ' . $folder . ' não possui permissao de escrita');
         }
 

--- a/src/Cnab/Remessa/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Santander.php
@@ -242,7 +242,7 @@ class Santander extends AbstractRemessa implements RemessaContract
     {
         $this->iniciaDetalhe();
         $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
-        $this->add(4, 7, '0001');
+        $this->add(4, 7, sprintf("%04d", $this->getIdremessa()));
         $this->add(8, 8, '3');
         $this->add(9, 13, Util::formatCnab('9', $this->iRegistrosLote, 5));
         $this->add(14, 14, 'R');

--- a/src/Cnab/Remessa/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Santander.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Created by PhpStorm.
  * User: simetriatecnologia
@@ -118,7 +119,7 @@ class Santander extends AbstractRemessa implements RemessaContract
     {
         $this->iniciaDetalhe();
         $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
-        $this->add(4, 7, '0001');
+        $this->add(4, 7, $this->getIdremessa());
         $this->add(8, 8, '3');
         $this->add(9, 13, Util::formatCnab('9', $this->iRegistrosLote, 5));
         $this->add(14, 14, 'P');
@@ -192,7 +193,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe();
 
         $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
-        $this->add(4, 7, '0001');
+        $this->add(4, 7, $this->getIdremessa());
         $this->add(8, 8, '3');
         $this->add(9, 13, Util::formatCnab('9', $this->iRegistrosLote, 5));
         $this->add(14, 14, 'Q');
@@ -222,12 +223,12 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(219, 221, Util::formatCnab('9', '000', 3));
         $this->add(222, 240, '');
 
-        if($boleto->getSacadorAvalista()) {
+        if ($boleto->getSacadorAvalista()) {
             $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
             $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
             $this->add(170, 209, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 30));
         }
-        
+
         return $this;
     }
 
@@ -307,8 +308,8 @@ class Santander extends AbstractRemessa implements RemessaContract
     public function getCodigoTransmissao()
     {
         return Util::formatCnab('9', $this->getAgencia(), 4)
-        . Util::formatCnab('9', '0000', 4)
-        . Util::formatCnab('9', $this->getCodigoCliente(), 7);
+            . Util::formatCnab('9', '0000', 4)
+            . Util::formatCnab('9', $this->getCodigoCliente(), 7);
     }
 
     /**

--- a/src/Cnab/Remessa/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Santander.php
@@ -119,7 +119,7 @@ class Santander extends AbstractRemessa implements RemessaContract
     {
         $this->iniciaDetalhe();
         $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
-        $this->add(4, 7, $this->getIdremessa());
+        $this->add(4, 7, sprintf("%04d", $this->getIdremessa()));
         $this->add(8, 8, '3');
         $this->add(9, 13, Util::formatCnab('9', $this->iRegistrosLote, 5));
         $this->add(14, 14, 'P');
@@ -138,7 +138,7 @@ class Santander extends AbstractRemessa implements RemessaContract
             $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
         }
         $this->add(18, 21, Util::formatCnab('9', $this->getAgencia(), 4));
-        $this->add(22, 22, Util::formatCnab('9', '', 1));
+        $this->add(22, 22, $this->getAgenciaDv() ?: Util::formatCnab('9', '', 1));
         $this->add(23, 31, Util::formatCnab('9', $this->getConta(), 9));
         $this->add(32, 32, $this->getContaDv() ?: CalculoDV::santanderContaCorrente($this->getAgencia(), $this->getConta()));
         $this->add(33, 41, Util::formatCnab('9', $this->getConta(), 9));
@@ -153,8 +153,8 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(63, 77, Util::formatCnab('9', $boleto->getNumeroDocumento(), 15));
         $this->add(78, 85, $boleto->getDataVencimento()->format('dmY'));
         $this->add(86, 100, Util::formatCnab('9', $boleto->getValor(), 15, 2));
-        $this->add(101, 104, Util::formatCnab('9', 0, 4));
-        $this->add(105, 105, Util::formatCnab('9', 0, 1));
+        $this->add(101, 104, Util::formatCnab('9', $this->getConta(), 4));
+        $this->add(105, 105, Util::formatCnab('9', $this->getContaDv(), 1));
         $this->add(106, 106, '');
         $this->add(107, 108, Util::formatCnab('9', $boleto->getEspecieDocCodigo('02', 240), 2));
         $this->add(109, 109, Util::formatCnab('9', 'N', 1));
@@ -193,7 +193,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe();
 
         $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
-        $this->add(4, 7, $this->getIdremessa());
+        $this->add(4, 7, sprintf("%04d", $this->getIdremessa()));
         $this->add(8, 8, '3');
         $this->add(9, 13, Util::formatCnab('9', $this->iRegistrosLote, 5));
         $this->add(14, 14, 'Q');
@@ -324,7 +324,7 @@ class Santander extends AbstractRemessa implements RemessaContract
          * HEADER DE LOTE
          */
         $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
-        $this->add(4, 7, '0001');
+        $this->add(4, 7, sprintf("%04d", $this->getIdremessa()));
         $this->add(8, 8, '1');
         $this->add(9, 9, 'R');
         $this->add(10, 11, '01');
@@ -339,7 +339,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(74, 103, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
         $this->add(104, 143, '');
         $this->add(144, 183, '');
-        $this->add(184, 191, Util::formatCnab('9', 0, 8));
+        $this->add(184, 191, sprintf("%08d", $this->getIdremessa()));
         $this->add(192, 199, date('dmY'));
         $this->add(200, 240, '');
 
@@ -355,7 +355,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->iniciaTrailerLote();
 
         $this->add(1, 3, Util::onlyNumbers($this->getCodigoBanco()));
-        $this->add(4, 7, '0001');
+        $this->add(4, 7, sprintf("%04d", $this->getIdremessa()));
         $this->add(8, 8, '5');
         $this->add(9, 17, '');
         $this->add(18, 23, Util::formatCnab('9', $this->getCountDetalhes() + 2, 6));


### PR DESCRIPTION
Enquanto eu gerava remessas Cnab240 para o banco Santander, me deparei com o problema de que o campo denominado no manual "**número de lote remessa**" não estava sendo preenchido no arquivo final, ocasionando em desconformidade com o manual mais recente do banco, disponível [aqui](https://www.santander.com.br/layout-de-arquivos).

Na sessão "Cobrança - Português", onde na sessão em que fala dos segmentos Header, P, Q e R, diz que as posições 004 - 007 devem ser preenchidas com o número de lote da remessa, que na biblioteca é denominado por "idremessa".

Também tomei a liberdade de adicionar a propriedade "agenciaDv", bem como seus getters e setters, tornando possível separar esses valores do número da agência.