### PR TITLE
Carteira 02, remessa cnab 400 Bradesco

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
@@ -72,7 +72,7 @@ class Bradesco extends AbstractRemessa implements RemessaContract
      * @var array
      */
 
-    protected $carteiras = ['04', '09', '28'];
+    protected $carteiras = ['02', '04', '09', '28'];
 
     /**
      * Caracter de fim de linha


### PR DESCRIPTION
Change log:
- Adicionado carteira '02' a lista de carteiras disponíveis da remessa Bradesco CNAB 400