### PR TITLE
Correção remessa bb CNAB240

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -507,7 +507,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(9, 17, '');
         $this->add(18, 23, Util::formatCnab('9', 1, 6));
         $this->add(24, 29, Util::formatCnab('9', $this->getCount(), 6));
-        $this->add(30, 35, Util::formatCnab('9', $this->getQtdeContasConc() ?? '000001', 6));
+        $this->add(30, 35, Util::formatCnab('9', $this->getQtdeContasConc() ?? '000000', 6));
         $this->add(36, 240, '');
 
         return $this;

--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -77,6 +77,20 @@ class Bb extends AbstractRemessa implements RemessaContract
     protected $variacaoCarteira;
 
     /**
+     * Variação da carteira
+     *
+     * @var string
+     */
+    protected $identificacaoDistribuicao;
+
+    /**
+     * Variação da carteira
+     *
+     * @var string
+     */
+    protected $qtdeContasConc;
+
+    /**
      * @return mixed
      */
     public function getConvenio()
@@ -141,6 +155,54 @@ class Bb extends AbstractRemessa implements RemessaContract
     }
 
     /**
+     * Retorna identificação da distribuição. Campo C010 da Febraban.
+     *
+     * @return string
+     */
+    public function getIdentificacaoDistribuicao()
+    {
+        return $this->identificacaoDistribuicao;
+    }
+
+    /**
+     * Seta a identificação da distribuição. Campo C010 da Febraban.
+     *
+     * @param string $identificacaoDistribuicao
+     *
+     * @return Bb
+     */
+    public function setIdentificacaoDistribuicao($identificacaoDistribuicao)
+    {
+        $this->identificacaoDistribuicao = $identificacaoDistribuicao;
+
+        return $this;
+    }
+
+    /**
+     * Retorna Quantidade de Contas para Conciliação (Lotes). Código G037 da Febraban.
+     *
+     * @return string
+     */
+    public function getQtdeContasConc()
+    {
+        return $this->qtdeContasConc;
+    }
+
+    /**
+     * Seta a Quantidade de Contas para Conciliação (Lotes). Código G037 da Febraban.
+     *
+     * @param string $identificacaoDistribuicao
+     *
+     * @return Bb
+     */
+    public function setQtdeContasConc($qtdeContasConc)
+    {
+        $this->qtdeContasConc = $qtdeContasConc;
+
+        return $this;
+    }
+
+    /**
      * @param BoletoContract $boleto
      *
      * @return $this
@@ -196,7 +258,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(59, 59, '');
         $this->add(60, 60, '');
         $this->add(61, 61, '');
-        $this->add(62, 62, '');
+        $this->add(62, 62, Util::formatCnab('9', $this->getIdentificacaoDistribuicao() ?? '0', 1));
         $this->add(63, 77, Util::formatCnab('9', $boleto->getNumeroDocumento(), 15)); //valor do número do documento
         $this->add(78, 85, $boleto->getDataVencimento()->format('dmY'));
         $this->add(86, 100, Util::formatCnab('9', $boleto->getValor(), 15, 2));
@@ -445,7 +507,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(9, 17, '');
         $this->add(18, 23, Util::formatCnab('9', 1, 6));
         $this->add(24, 29, Util::formatCnab('9', $this->getCount(), 6));
-        $this->add(30, 35, '000001');
+        $this->add(30, 35, Util::formatCnab('9', $this->getQtdeContasConc() ?? '000001', 6));
         $this->add(36, 240, '');
 
         return $this;


### PR DESCRIPTION
Ao gerar um arquivo de remessa do Banco do Brasil (Eduardokum\LaravelBoleto\Cnab\Remessa\Cnab240\Banco\Bb) recebo sempre dois erros relacionados aos seguintes campos:
- Qtde de Contas p/ Conc. (Lotes): G037
- Identificação da Distribuição: C010

![Captura de tela de 2023-01-10 18-29-15](https://user-images.githubusercontent.com/42716264/211668187-909e552c-e9f2-4063-a492-dec11d0496f8.png)

Seguindo as especificações do [Leiaute CNAB 240](https://www.bb.com.br/docs/pub/emp/empl/dwn/CNAB240SegPQRSTY.pdf) do Banco do Brasil de maio/2021, as informações inseridas nesses dois campos estavam incorretas.

A solução proposta é utilizar o método Util::formatCnab para preencher esses campos adicionando dois setters para que seja possível controlar o valor desses campos. Caso o desenvolvedor não preencher esses campos, o sistema fornece um valor padrão válido.