### PR TITLE
Logo boleto

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">5.5.0",
         "ext-intl": "*",
         "ext-mbstring": "*",
-        "laravel/framework": "^5.0||^6.0||^7.0",
+        "laravel/framework": "^5.0||^6.0||^7.0||8.0",
         "neitanod/forceutf8": "^2.0",
         "setasign/fpdf": "^1.8"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">5.5.0",
         "ext-intl": "*",
         "ext-mbstring": "*",
-        "laravel/framework": "^5.0||^6.0||^7.0||8.0",
+        "laravel/framework": "^5.0||^6.0||^7.0||^8.0",
         "neitanod/forceutf8": "^2.0",
         "setasign/fpdf": "^1.8"
     },

--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -1278,7 +1278,7 @@ abstract class AbstractBoleto implements BoletoContract
      */
     public function getLogo()
     {
-        return $this->logo ? $this->logo : "http://dummyimage.com/300x70/f5/0.png&text=Sem+Logo";
+        return $this->logo;
     }
 
     /**
@@ -1288,8 +1288,11 @@ abstract class AbstractBoleto implements BoletoContract
      */
     public function getLogoBase64()
     {
-        return 'data:image/' . pathinfo($this->getLogo(), PATHINFO_EXTENSION) .
-            ';base64,' . base64_encode(file_get_contents($this->getLogo()));
+        if($this->getLogo())
+        {
+            return 'data:image/' . pathinfo($this->getLogo(), PATHINFO_EXTENSION) .
+                ';base64,' . base64_encode(file_get_contents($this->getLogo()));
+        }
     }
 
     /**

--- a/src/Boleto/AbstractBoleto.php
+++ b/src/Boleto/AbstractBoleto.php
@@ -51,7 +51,17 @@ abstract class AbstractBoleto implements BoletoContract
      *
      * @var float
      */
+    
     protected $valor;
+
+     /**
+     * Valor do abatimento
+     *
+     * @var float
+     */
+    protected $valorAbatimento;
+
+
     /**
      * Desconto total do boleto
      *
@@ -1047,6 +1057,7 @@ abstract class AbstractBoleto implements BoletoContract
         return $this;
     }
 
+    
     /**
      * Retorna o valor total do boleto (incluindo taxas)
      *
@@ -1055,6 +1066,30 @@ abstract class AbstractBoleto implements BoletoContract
     public function getValor()
     {
         return Util::nFloat($this->valor, 2, false);
+    }
+
+     /**
+     * Define o valor do abatimento
+     *
+     * @param  string $valorAbatimento
+     *
+     * @return AbstractBoleto
+     */
+    public function setValorAbatimento($valorAbatimento)
+    {
+        $this->valorAbatimento = Util::nFloat($valorAbatimento, 2, false);
+
+        return $this;
+    }
+
+    /**
+     * Retorna o valor do abatimento
+     *
+     * @return string
+     */
+    public function getValorAbatimento()
+    {
+        return Util::nFloat($this->valorAbatimento, 2, false);
     }
 
     /**

--- a/src/Cnab/Remessa/Cnab240/Banco/Bancoob.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bancoob.php
@@ -76,6 +76,28 @@ class Bancoob extends AbstractRemessa implements RemessaContract
      */
     protected $fimArquivo = "";
 
+    protected $convenio;
+
+    /**
+     * @return mixed
+     */
+    public function getConvenio()
+    {
+        return $this->convenio;
+    }
+
+    /**
+     * @param mixed $convenio
+     *
+     * @return Bancoob
+     */
+    public function setConvenio($convenio)
+    {
+        $this->convenio = ltrim($convenio, 0);
+
+        return $this;
+    }
+    
     /**
      * @param BoletoContract $boleto
      *

--- a/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
@@ -79,6 +79,13 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     protected $codigoCliente;
 
     /**
+     * Codigo do cliente office banking junto ao banco.
+     *
+     * @var string
+     */
+    protected $codigoClienteOfficeBanking;
+
+    /**
      * Retorna o codigo do cliente.
      *
      * @return mixed
@@ -98,6 +105,30 @@ class Banrisul extends AbstractRemessa implements RemessaContract
     public function setCodigoCliente($codigoCliente)
     {
         $this->codigoCliente = $codigoCliente;
+
+        return $this;
+    }
+
+    /**
+     * Retorna o codigo do cliente office banking.
+     *
+     * @return mixed
+     */
+    public function getCodigoClienteOfficeBanking()
+    {
+        return $this->codigoClienteOfficeBanking;
+    }
+
+    /**
+     * Seta o codigo do cliente office banking.
+     *
+     * @param mixed $officeBanking
+     *
+     * @return Banrisul
+     */
+    public function setCodigoClienteOfficeBanking($officeBanking)
+    {
+        $this->codigoClienteOfficeBanking = $officeBanking;
 
         return $this;
     }

--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -212,7 +212,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');
         $this->add(151, 165, Util::formatCnab('9', $boleto->getDesconto(), 15, 2));
         $this->add(166, 180, Util::formatCnab('9', 0, 15, 2));
-        $this->add(181, 195, Util::formatCnab('9', 0, 15, 2));
+        $this->add(181, 195, Util::formatCnab('9', $boleto->getValorAbatimento(), 15, 2));
         $this->add(196, 220, Util::formatCnab('X', $boleto->getNumeroControle(), 25));
         $this->add(221, 221, self::PROTESTO_NAO_PROTESTAR);
         if ($boleto->getDiasProtesto() > 0) {

--- a/src/Cnab/Remessa/Cnab240/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bradesco.php
@@ -193,7 +193,7 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');
         $this->add(151, 165, Util::formatCnab('9', $boleto->getDesconto(), 15, 2));
         $this->add(166, 180, Util::formatCnab('9', 0, 15, 2));
-        $this->add(181, 195, Util::formatCnab('9', 0, 15, 2));
+        $this->add(181, 195, Util::formatCnab('9', $boleto->getValorAbatimento(), 15, 2));
         $this->add(196, 220, Util::formatCnab('X', $boleto->getNumeroControle(), 25));
         $this->add(221, 221, self::PROTESTO_SEM);
         if ($boleto->getDiasProtesto() > 0) {

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -165,7 +165,7 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');
         $this->add(151, 165, Util::formatCnab('9', $boleto->getDesconto(), 15, 2));
         $this->add(166, 180, Util::formatCnab('9', 0, 15, 2));
-        $this->add(181, 195, Util::formatCnab('9', 0, 15, 2));
+        $this->add(181, 195, Util::formatCnab('9', $boleto->getValorAbatimento(), 15, 2));
         $this->add(196, 220, Util::formatCnab('X', $boleto->getNumeroDocumento(), 25));
         $this->add(221, 221, self::PROTESTO_SEM);
         if ($boleto->getDiasProtesto() > 0) {

--- a/src/Cnab/Remessa/Cnab240/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Itau.php
@@ -128,7 +128,7 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');
         $this->add(151, 165, Util::formatCnab('9', $boleto->getDesconto(), 15, 2));
         $this->add(166, 180, Util::formatCnab('9', 0, 15, 2));
-        $this->add(181, 195, Util::formatCnab('9', 0, 15, 2));
+        $this->add(181, 195, Util::formatCnab('9', $boleto->getValorAbatimento(), 15, 2));
         $this->add(196, 220, Util::formatCnab('X', $boleto->getNumeroControle(), 25));
         $this->add(221, 221, self::PROTESTO_SEM);
         if ($boleto->getDiasProtesto() > 0) {

--- a/src/Cnab/Remessa/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Santander.php
@@ -165,7 +165,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');
         $this->add(151, 165, Util::formatCnab('9', $boleto->getDesconto(), 15, 2));
         $this->add(166, 180, Util::formatCnab('9', 0, 15, 2));
-        $this->add(181, 195, Util::formatCnab('9', 0, 15, 2));
+        $this->add(181, 195, Util::formatCnab('9', $boleto->getValorAbatimento(), 15, 2));
         $this->add(196, 220, '');
         $this->add(221, 221, self::PROTESTO_SEM);
         if ($boleto->getDiasProtesto() > 0) {

--- a/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
@@ -38,7 +38,7 @@ class Sicredi extends AbstractRemessa implements RemessaContract
     const PROTESTO_NAO_PROTESTAR = '3';
     const PROTESTO_AUTOMATICO = '9';
 
-    public function __construct(array $params)
+    public function __construct(array $params = [])
     {
         parent::__construct($params);
         $this->setCarteira('A'); //Carteira Simples 'A'
@@ -65,6 +65,30 @@ class Sicredi extends AbstractRemessa implements RemessaContract
      * @var string
      */
     protected $codigoCliente;
+
+     /**
+     * Retorna o codigo do cliente.
+     *
+     * @return mixed
+     */
+    public function getCodigoCliente()
+    {
+        return $this->codigoCliente;
+    }
+
+    /**
+     * Seta o codigo do cliente.
+     *
+     * @param mixed $codigoCliente
+     *
+     * @return Sicredi
+     */
+    public function setCodigoCliente($codigoCliente)
+    {
+        $this->codigoCliente = $codigoCliente;
+
+        return $this;
+    }
 
     /**
      * Define o código da carteira (Com ou sem registro)
@@ -142,7 +166,7 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(119, 126, $boleto->getJurosApos() == 0 ? '00000000' :
                $boleto->getDataVencimentoApos()->format('dmY'));
         $this->add(127, 141, Util::formatCnab('9', $boleto->getMoraDia(), 15, 2)); //Valor da mora/dia ou Taxa mensal
-        $this->add(142, 142, '1'); // '1' = Valor Fixo Até a Data Informada
+        $this->add(142, 142, $boleto->getDesconto() > 0 ? '1' : '0');
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');
         $this->add(151, 165, Util::formatCnab('9', $boleto->getDesconto(), 15, 2));
         $this->add(166, 180, Util::formatCnab('9', 0, 15, 2));

--- a/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
@@ -170,7 +170,7 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(143, 150, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmY') : '00000000');
         $this->add(151, 165, Util::formatCnab('9', $boleto->getDesconto(), 15, 2));
         $this->add(166, 180, Util::formatCnab('9', 0, 15, 2));
-        $this->add(181, 195, Util::formatCnab('9', 0, 15, 2));
+        $this->add(181, 195, Util::formatCnab('9', $boleto->getValorAbatimento(), 15, 2));
         $this->add(196, 220, Util::formatCnab('X', $boleto->getNumeroControle(), 25));
         $this->add(221, 221, self::PROTESTO_SEM);
         if ($boleto->getDiasProtesto() > 0) {

--- a/src/Cnab/Remessa/Cnab400/Banco/Bancoob.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bancoob.php
@@ -227,7 +227,7 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 193, '9');
         $this->add(194, 205, Util::formatCnab('9', 0, 12, 2));
-        $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
+        $this->add(206, 218, Util::formatCnab('9', $boleto->getValorAbatimento(), 13, 2));
         $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
         $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 271, Util::formatCnab('X', $boleto->getPagador()->getNome(), 37));

--- a/src/Cnab/Remessa/Cnab400/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bb.php
@@ -290,7 +290,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(174, 179, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmy') : '000000');
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
-        $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
+        $this->add(206, 218, Util::formatCnab('9', $boleto->getValorAbatimento(), 13, 2));
         $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
         $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 271, Util::formatCnab('X', $boleto->getPagador()->getNome(), 37));

--- a/src/Cnab/Remessa/Cnab400/Banco/Bnb.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bnb.php
@@ -157,7 +157,7 @@ class Bnb extends AbstractRemessa implements RemessaContract
         $this->add(174, 179, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmy') : '000000');
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
-        $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
+        $this->add(206, 218, Util::formatCnab('9', $boleto->getValorAbatimento(), 13, 2));
         $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
         $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
@@ -222,7 +222,7 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(174, 179, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmy') : '000000');
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
-        $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
+        $this->add(206, 218, Util::formatCnab('9', $boleto->getValorAbatimento(), 13, 2));
         $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
         $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
@@ -194,7 +194,7 @@ class Caixa  extends AbstractRemessa implements RemessaContract
         $this->add(174, 179, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmy') : '000000');
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
-        $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
+        $this->add(206, 218, Util::formatCnab('9', $boleto->getValorAbatimento(), 13, 2));
         $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
         $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Hsbc.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Hsbc.php
@@ -200,7 +200,7 @@ class Hsbc extends AbstractRemessa implements RemessaContract
             $this->add(206, 215, Util::formatCnab('9', $boleto->getMulta(), 2, 2));
             $this->add(206, 218, Util::formatCnab('9', $boleto->getJurosApos(), 3));
         } else {
-            $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
+            $this->add(206, 218, Util::formatCnab('9', $boleto->getValorAbatimento(), 13, 2));
         }
         $this->add(161, 173, Util::formatCnab('9', $boleto->getMoraDia(), 13, 2));
         $this->add(174, 179, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmy') : '000000');

--- a/src/Cnab/Remessa/Cnab400/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Itau.php
@@ -221,7 +221,7 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(174, 179, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmy') : '000000');
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
-        $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
+        $this->add(206, 218, Util::formatCnab('9', $boleto->getValorAbatimento(), 13, 2));
         $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
         $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
         $this->add(235, 264, Util::formatCnab('X', $boleto->getPagador()->getNome(), 30));

--- a/src/Cnab/Remessa/Cnab400/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Santander.php
@@ -213,7 +213,7 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(174, 179, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmy') : '000000');
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
-        $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
+        $this->add(206, 218, Util::formatCnab('9', $boleto->getValorAbatimento(), 13, 2));
         $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
         $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));

--- a/src/Contracts/Boleto/Boleto.php
+++ b/src/Contracts/Boleto/Boleto.php
@@ -125,6 +125,12 @@ interface Boleto
      */
     public function getValor();
 
+
+    /**
+     * @return mixed
+     */
+    public function getValorAbatimento();
+
     /**
      * @return mixed
      */

--- a/tests/Remessa/RemessaCnab240Test.php
+++ b/tests/Remessa/RemessaCnab240Test.php
@@ -101,10 +101,12 @@ class RemessaCnab240Test extends TestCase
 //    }
 
     public function testRemessaItauCnab240(){
+        
         $boleto = new Boleto\Itau([
             'logo' => realpath(__DIR__ . '/../logos/') . DIRECTORY_SEPARATOR . '033.png',
             'dataVencimento' => new \Carbon\Carbon(),
             'valor' => 100,
+            'valorAbatimento' => 15.00,
             'multa' => false,
             'juros' => false,
             'numero' => 1,


### PR DESCRIPTION
Retirado a imagem sem logo.
Assim o boleto é impresso com imagem ou se não tiver simplemente só aparece as informações do credor.