### PR TITLE
Compatibilidade PHP 8.1+

### DIFF
--- a/src/Boleto/Render/Pdf.php
+++ b/src/Boleto/Render/Pdf.php
@@ -510,7 +510,7 @@ class Pdf extends AbstractPdf implements PdfContract
     {
         foreach ($lista as $d) {
             $pulaLinha -= 2;
-            $this->MultiCell(0, $this->cell - 0.2, $this->_(preg_replace('/(%)/', '%$1', $d)), 0, 1);
+            $this->MultiCell(0, $this->cell - 0.2, $this->_(preg_replace('/(%)/', '%$1', $d ?? '')), 0, 1);
         }
 
         return $pulaLinha;


### PR DESCRIPTION
Elimina Deprecation Warning (E_DEPRECATED) no PHP 8.1+ na geração de linhas vazias no espelho do boleto.

```
preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
```