### PR TITLE
fix: Espaçamento para linha pontilhada não ficar rente ao código de b…

### DIFF
--- a/src/Boleto/Render/view/carne.blade.php
+++ b/src/Boleto/Render/view/carne.blade.php
@@ -117,7 +117,7 @@
                 @include('BoletoHtmlRender::partials/ficha-compensacao')
             </div>
             <div style="clear: both"></div>
-            <div class="linha-pontilhada">Corte na linha pontilhada</div>
+            <div class="linha-pontilhada" style="margin-top: 10px;">Corte na linha pontilhada</div>
         </div>
 
         @if(count($boletos) > 3 && $i > 0 && ($i+1) % 3 === 0)


### PR DESCRIPTION
Apenas adicionando um espaçamento pois a linha pontilhada do carnê estava junto com o código de barras.