### PR TITLE
Layout BB CNAB240 de setembro de 2023

### DIFF
--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -201,7 +201,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(78, 85, $boleto->getDataVencimento()->format('dmY'));
         $this->add(86, 100, Util::formatCnab('9', $boleto->getValor(), 15, 2));
         $this->add(101, 105, '00000');
-        $this->add(106, 106, '0');
+        $this->add(106, 106, '');
         $this->add(107, 108, Util::formatCnab('9', $boleto->getEspecieDocCodigo(), 2));
         $this->add(109, 109, Util::formatCnab('9', $boleto->getAceite(), 1));
         $this->add(110, 117, $boleto->getDataDocumento()->format('dmY'));

--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -389,7 +389,7 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(9, 9, 'R');
         $this->add(10, 11, '01');
         $this->add(12, 13, '');
-        $this->add(14, 16, '042');
+        $this->add(14, 16, '043');
         $this->add(17, 17, '');
         $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
         $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));


### PR DESCRIPTION
Correções segundo a documentação do layout CNAB 240 de setembro de 2023.

- no segmentoP, posição 106, deve ser informado espaço branco para o dígito verificador da agência
- versão do layout do lote, deve estar em conformidade com a versão do layout declarado no header.  Alterado para 43 visto que no header está informado a versão 84.

Segue abaixo documentação.

[CNAB240SegPQRSTY(11) (1).pdf](https://github.com/eduardokum/laravel-boleto/files/13473903/CNAB240SegPQRSTY.11.1.pdf)
