### PR TITLE
Fix: converter e-mails para minúsculas na atualização de chav…

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Santander.php
@@ -258,7 +258,7 @@ class Santander extends AbstractRemessa implements RemessaContract
             $this->add(25, 37, Util::formatCnab('9', $boleto->getValor(), 13, 2));
             $this->add(38, 42, Util::formatCnab('9', 100, 5, 2));
             $this->add(43, 43, Util::formatCnab('9', $tipoChave[$boleto->getPixChaveTipo()], 1));
-            $this->add(44, 120, Util::formatCnab('X', $boleto->getPixChave(), 77));
+            $this->add(44, 120, Util::formatCnab('Z', $boleto->getPixChave(), 77));
             $this->add(121, 155, Util::formatCnab('X', $boleto->getID(), 35));
             $this->add(156, 394, '');
             $this->add(395, 400, Util::formatCnab('9', $this->iRegistros + 1, 6));

--- a/src/Util.php
+++ b/src/Util.php
@@ -501,14 +501,19 @@ final class Util
             $type = 's';
             $valor = ($dec > 0) ? sprintf("%.{$dec}f", $valor) : $valor;
             $valor = str_replace([',', '.'], '', $valor);
-        } elseif (in_array($tipo, ['A', 'X'])) {
+        } elseif (in_array($tipo, ['A', 'X', 'Z'])) { // Adiciona 'x' como uma condição válida
             $left = '-';
             $type = 's';
         } else {
             throw new ValidationException('Tipo inválido');
         }
 
-        return sprintf("%{$left}{$sFill}{$tamanho}{$type}", mb_substr($valor, 0, $tamanho));
+        // Verifica se o tipo é 'x' minúsculo e então retorna a string em minúsculas
+        if ($tipo === 'Z') {
+            return strtolower(sprintf("%{$left}{$sFill}{$tamanho}{$type}", mb_substr($valor, 0, $tamanho)));
+        } else {
+            return sprintf("%{$left}{$sFill}{$tamanho}{$type}", mb_substr($valor, 0, $tamanho));
+        }
     }
 
     /**


### PR DESCRIPTION
…e PIX do Santander

Este commit ajusta o módulo de processamento de chave PIX do Santander para garantir que todos os e-mails sejam convertidos para minúsculas. Essa mudança melhora a consistência dos dados e evita problemas relacionados à sensibilidade de maiúsculas e minúsculas em comparações e validações de e-mail.

Ao usar email em maiusculo no santander a transmissão do arquivo da erro. 