### PR TITLE
Adicionado ao docker file extensão GD para teste unitário não gerar erro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,15 +9,14 @@ RUN apk add --no-cache \
   libzip-dev \
   zlib-dev \
   libsodium-dev \
-  icu-dev
+  icu-dev \
+  libpng-dev
 
 RUN docker-php-ext-configure intl
-RUN docker-php-ext-install zip sodium intl
+RUN docker-php-ext-install zip sodium intl gd
 RUN docker-php-ext-enable zip sodium
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
-
-
 
 WORKDIR /var/www
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,12 @@
-version: '3.7'
-
 services:
-
-  laravel-boleto:
+  laravel.boleto:
     build: .
     container_name: laravel-boleto
     tty: true
     volumes:
-      - .:/var/www
+      - '.:/var/www'
     networks:
       - laravel-boleto-network
-
 networks:
   laravel-boleto-network:
     driver: bridge


### PR DESCRIPTION
Realizei alguns testes na dentro do docker e identifiquei que estava gerando erro na hora de executar o PHPunit por falta da extensão GD no arquivo do docker.

- Adicionado extensão GD no Dockerfile;
- Formatado docker-compose.yml.