### PR TITLE
:bug: Sicredi: Ajuste numeroDocumento, na remessa do Sicredi

### DIFF
--- a/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
@@ -235,7 +235,7 @@ class Sicredi extends AbstractRemessa implements RemessaContract
             $this->add(102, 181, Util::formatCnab('X', $boleto->getInstrucoes()[1], 80));
             $this->add(182, 261, Util::formatCnab('X', $boleto->getInstrucoes()[2], 80));
             $this->add(262, 341, Util::formatCnab('X', $boleto->getInstrucoes()[3], 80));
-            $this->add(342, 351, Util::formatCnab('9', $boleto->getNumeroDocumento(), 10));
+            $this->add(342, 351, Util::formatCnab('X', $boleto->getNumeroDocumento(), 10));
             $this->add(352, 394, '');
             $this->add(395, 400, Util::formatCnab('9', $this->iRegistros + 1, 6));
         }


### PR DESCRIPTION
Ajustado para o numero do documento, ser alinhado como texto na remessa, que estava gerando erro no ambiente de homologação dos boletos.

Ao tentar homologar retornava o seguinte erro:
![image](https://github.com/user-attachments/assets/84895084-c5ac-4f4e-bf14-e35ab5caeab2)


Ajustado para o numeroDocumento de 0000000015 para 15 alinhado a esquerda como os outros campos textos e corrigiu o problema.

![image](https://github.com/user-attachments/assets/41c3f050-dfd8-4bee-bb4d-949b24ecca02)
