### PR TITLE
Suporte a Laravel 12 + versao estavel de laravel-mail-auto-embed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-openssl": "*",
-        "eduardokum/laravel-mail-auto-embed": "dev-master",
+        "eduardokum/laravel-mail-auto-embed": "^2.0",
         "chillerlan/php-qrcode": "^3.0|^4.0|^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -33,12 +33,12 @@
     },
     "autoload": {
         "psr-4": {
-            "Eduardokum\LaravelBoleto\\": "src"
+            "Eduardokum\\LaravelBoleto\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Eduardokum\LaravelBoleto\Tests\\": "tests"
+            "Eduardokum\\LaravelBoleto\\Tests\\": "tests"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">5.5.0",
         "ext-intl": "*",
         "ext-mbstring": "*",
-        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "neitanod/forceutf8": "^2.0",
         "setasign/fpdf": "^1.8",
         "ext-curl": "*",
@@ -28,17 +28,17 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
         "friendsofphp/php-cs-fixer": "*"
     },
     "autoload": {
         "psr-4": {
-            "Eduardokum\\LaravelBoleto\\": "src"
+            "Eduardokum\LaravelBoleto\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Eduardokum\\LaravelBoleto\\Tests\\": "tests"
+            "Eduardokum\LaravelBoleto\Tests\\": "tests"
         }
     },
     "config": {


### PR DESCRIPTION
Resolve #771.

## Mudancas

1. **laravel/framework**: adicionado `^12.0` ao constraint de versoes suportadas.
2. **eduardokum/laravel-mail-auto-embed**: trocado de `dev-master` para `^2.0` (versao estavel 2.x ja publicada no Packagist e compativel com Laravel 6-13). Isso permite instalar a lib em projetos com `minimum-stability: stable`, sem forcar os consumidores a declarar o auxiliar como `dev-master`.
3. **orchestra/testbench** (require-dev): adicionado `^10.0` para possibilitar rodar testes em Laravel 12.

## Teste

Fork aplicado e validado em um projeto Laravel 12 + PHP 8.5: `composer update` resolve e instala sem conflito, e as classes principais (Pdf renderer, bancos, Pessoa, Cnab Remessa, Cnab Retorno Factory) carregam via autoload.

Mudanca minima, so no composer.json — nao mexe em src/.