### PR TITLE
Adicionar compatibilidade com Laravel 13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3.25-fpm-alpine3.11
+FROM php:8.3-fpm-alpine
 
 RUN apk add --no-cache \
   openssl \
@@ -10,7 +10,9 @@ RUN apk add --no-cache \
   zlib-dev \
   libsodium-dev \
   icu-dev \
-  libpng-dev
+  icu-data-full \
+  libpng-dev \
+  linux-headers
 
 RUN docker-php-ext-configure intl
 RUN docker-php-ext-install zip sodium intl gd

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "php": ">5.5.0",
     "ext-intl": "*",
     "ext-mbstring": "*",
-    "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
+    "laravel/framework": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
     "neitanod/forceutf8": "^2.0",
     "setasign/fpdf": "^1.8",
     "ext-curl": "*",
@@ -28,7 +28,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
-    "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0",
+    "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
     "friendsofphp/php-cs-fixer": "*"
   },
   "autoload": {


### PR DESCRIPTION
## Mudanças

O Laravel 13 foi lançado e atualmente o pacote suporta apenas até o Laravel 12. Este PR adiciona a compatibilidade com o Laravel 13 e atualiza o ambiente de desenvolvimento para refletir os requisitos mínimos da nova versão.

Mudanças nesse PR:
- adicionado suporte de versão do Laravel 13 no projeto 
- adicionado suporte ao orchestra/testbench 11
- atualizada versão da imagem base do build do php para 8.3
- adicionadas libs obrigatórias na imagem base do build do php

## Testes

Testes unitários e Build testados.