### PR TITLE
Add support for alphanumeric CNPJ

### DIFF
--- a/src/Boleto/Banco/Inter.php
+++ b/src/Boleto/Banco/Inter.php
@@ -244,7 +244,7 @@ class Inter extends AbstractBoleto implements BoletoAPIContract
 
         return array_filter([
             'seuNumero'           => $this->getNumero(),
-            'cnpjCPFBeneficiario' => sprintf('%014s', Util::onlyNumbers($this->getBeneficiario()->getDocumento())),
+            'cnpjCPFBeneficiario' => Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14),
             'valorNominal'        => Util::nFloat($this->getValor(), 2, false),
             'dataEmissao'         => $this->getDataDocumento()->format('Y-m-d'),
             'dataVencimento'      => $this->getDataVencimento()->format('Y-m-d'),
@@ -257,7 +257,7 @@ class Inter extends AbstractBoleto implements BoletoAPIContract
             'multa'               => $multa,
             'mora'                => $mora,
             'pagador'             => [
-                'tipoPessoa' => strlen(Util::onlyNumbers($this->getPagador()->getDocumento())) == 14 ? 'JURIDICA' : 'FISICA',
+                'tipoPessoa' => Util::isCnpj($this->getPagador()->getDocumento()) ? 'JURIDICA' : 'FISICA',
                 'nome'       => $this->getPagador()->getNome(),
                 'endereco'   => $enderecoSplit($this->getPagador()->getEndereco())['endereco'],
                 'numero'     => $enderecoSplit($this->getPagador()->getEndereco())['numero'],
@@ -265,7 +265,7 @@ class Inter extends AbstractBoleto implements BoletoAPIContract
                 'cep'        => Util::onlyNumbers($this->getPagador()->getCep()),
                 'uf'         => $this->getPagador()->getUf(),
                 'cidade'     => $this->getPagador()->getCidade(),
-                'cnpjCpf'    => Util::onlyNumbers($this->getPagador()->getDocumento()),
+                'cnpjCpf'    => Util::onlyDocument($this->getPagador()->getDocumento()),
             ],
         ]);
     }

--- a/src/Boleto/Banco/Sisprime.php
+++ b/src/Boleto/Banco/Sisprime.php
@@ -322,8 +322,8 @@ class Sisprime extends AbstractBoleto implements BoletoContract
             'nossoNumero'   => null,
             'pagador' => [
                 'nomeRazaoSocial' => substr($this->getPagador()->getNome(), 0, 40),
-                'tipoPessoa'      => strlen(Util::onlyNumbers($this->getPagador()->getDocumento())) == 14 ? 'J' : 'F',
-                'numeroDocumento' => Util::onlyNumbers($this->getPagador()->getDocumento()),
+                'tipoPessoa'      => Util::isCnpj($this->getPagador()->getDocumento()) ? 'J' : 'F',
+                'numeroDocumento' => Util::onlyDocument($this->getPagador()->getDocumento()),
                 'nomeFantasia'    => $this->getPagador()->getNomeFantasia(),
                 'email'           => $this->getPagador()->getEmail(),
                 'endereco' => [

--- a/src/Boleto/Banco/Unicred.php
+++ b/src/Boleto/Banco/Unicred.php
@@ -346,8 +346,8 @@ class Unicred extends AbstractBoleto implements BoletoContract
             'nossoNumero'   => null,
             'pagador' => [
                 'nomeRazaoSocial' => substr($this->getPagador()->getNome(), 0, 40),
-                'tipoPessoa'      => strlen(Util::onlyNumbers($this->getPagador()->getDocumento())) == 14 ? 'J' : 'F',
-                'numeroDocumento' => Util::onlyNumbers($this->getPagador()->getDocumento()),
+                'tipoPessoa'      => Util::isCnpj($this->getPagador()->getDocumento()) ? 'J' : 'F',
+                'numeroDocumento' => Util::onlyDocument($this->getPagador()->getDocumento()),
                 'nomeFantasia'    => $this->getPagador()->getNomeFantasia(),
                 'email'           => $this->getPagador()->getEmail(),
                 'endereco' => [

--- a/src/Cnab/Remessa/Cnab240/Banco/Ailos.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Ailos.php
@@ -337,8 +337,8 @@ class Ailos extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_CUSTOM) {
             $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 73, Util::formatCnab('X', str_replace('&', 'E', Util::normalizeChars($boleto->getPagador()->getNome())), 40));
         $this->add(74, 113, Util::formatCnab('X', str_replace('&', 'E', Util::normalizeChars($boleto->getPagador()->getEndereco())), 40));
         $this->add(114, 128, Util::formatCnab('X', str_replace('&', 'E', Util::normalizeChars($boleto->getPagador()->getBairro())), 15));
@@ -354,8 +354,8 @@ class Ailos extends AbstractRemessa implements RemessaContract
         $this->add(233, 240, '');
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 209, Util::formatCnab('X', str_replace('&', 'E', Util::normalizeChars($boleto->getSacadorAvalista()->getNome())), 30));
         }
 
@@ -377,8 +377,8 @@ class Ailos extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(33, 52, Util::formatCnab('X', Util::formatCnab('9', Util::onlyNumbers($this->getConvenio()), 6), 20));
         $this->add(53, 57, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(58, 58, $this->getAgenciaDv());
@@ -421,8 +421,8 @@ class Ailos extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '');
         $this->add(14, 16, '045');
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(34, 53, Util::formatCnab('X', Util::formatCnab('9', Util::onlyNumbers($this->getConvenio()), 6), 20));
         $this->add(54, 58, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(59, 59, $this->getAgenciaDv());

--- a/src/Cnab/Remessa/Cnab240/Banco/Bancoob.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bancoob.php
@@ -200,8 +200,8 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_ALTERACAO) {
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 73, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(74, 113, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(114, 128, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 15));
@@ -216,8 +216,8 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->add(213, 240, Util::formatCnab('X', '', 28));
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 209, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 40));
         }
 
@@ -283,8 +283,8 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(33, 52, '');
         $this->add(53, 57, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(58, 58, ! is_null($this->getAgenciaDv()) ? $this->getAgenciaDv() : CalculoDV::bancoobAgencia($this->getAgencia()));
@@ -326,8 +326,8 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '');
         $this->add(14, 16, '040');
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(34, 53, '');
         $this->add(54, 58, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(59, 59, ! is_null($this->getAgenciaDv()) ? $this->getAgenciaDv() : CalculoDV::bancoobAgencia($this->getAgencia()));

--- a/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Banrisul.php
@@ -204,8 +204,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_ALTERACAO) {
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 73, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(74, 113, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(114, 128, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 15));
@@ -220,8 +220,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(213, 240, '');
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 209, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 30));
         }
 
@@ -251,8 +251,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
         $this->add(18, 19, '01');
-        $this->add(20, 20, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(21, 35, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+        $this->add(20, 20, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+        $this->add(21, 35, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
         $this->add(36, 75, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 40));
         $this->add(76, 115, Util::formatCnab('X', $boleto->getSacadorAvalista()->getEndereco(), 40));
         $this->add(116, 130, Util::formatCnab('X', $boleto->getSacadorAvalista()->getBairro(), 15));
@@ -279,8 +279,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(33, 52, Util::formatCnab('9', Util::onlyNumbers($this->getCodigoCliente()), 20));
         $this->add(53, 57, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(58, 58, '');
@@ -329,8 +329,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '');
         $this->add(14, 16, '020');
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(34, 53, Util::formatCnab('9', Util::onlyNumbers($this->getCodigoCliente()), 20));
         $this->add(54, 58, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(59, 59, '');

--- a/src/Cnab/Remessa/Cnab240/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bb.php
@@ -250,8 +250,8 @@ class Bb extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_CUSTOM) {
             $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 73, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(74, 113, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(114, 128, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 15));
@@ -266,8 +266,8 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(213, 240, '');
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 209, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 30));
         }
 
@@ -339,8 +339,8 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(33, 41, Util::formatCnab('9', Util::onlyNumbers($this->getConvenio()), 9));
         $this->add(42, 45, '0014');
         $this->add(46, 47, Util::formatCnab('9', $this->getCarteira(), 2));
@@ -385,8 +385,8 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '');
         $this->add(14, 16, '043');
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(34, 42, Util::formatCnab('9', Util::onlyNumbers($this->getConvenio()), 9));
         $this->add(43, 46, '0014');
         $this->add(47, 48, Util::formatCnab('9', $this->getCarteira(), 2));

--- a/src/Cnab/Remessa/Cnab240/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Bradesco.php
@@ -228,8 +228,8 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_CUSTOM) {
             $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 73, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(74, 113, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(114, 128, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 15));
@@ -244,8 +244,8 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(213, 240, '');
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 209, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 30));
         }
 
@@ -319,8 +319,8 @@ class Bradesco extends AbstractRemessa implements RemessaContract
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
         $this->add(18, 19, '01');
-        $this->add(20, 20, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(21, 35, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+        $this->add(20, 20, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+        $this->add(21, 35, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
         $this->add(36, 75, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 40));
         $this->add(76, 115, Util::formatCnab('X', $boleto->getSacadorAvalista()->getEndereco(), 40));
         $this->add(116, 130, Util::formatCnab('X', $boleto->getSacadorAvalista()->getBairro(), 15));
@@ -347,8 +347,8 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(33, 52, Util::formatCnab('9', Util::onlyNumbers($this->getCodigoCliente()), 20));
         $this->add(53, 57, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(58, 58, ! is_null($this->getAgenciaDv()) ? $this->getAgenciaDv() : CalculoDV::bradescoAgencia($this->getAgencia()));
@@ -389,8 +389,8 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '');
         $this->add(14, 16, '042');
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(34, 53, Util::formatCnab('9', Util::onlyNumbers($this->getCodigoCliente()), 20));
         $this->add(54, 58, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(59, 59, ! is_null($this->getAgenciaDv()) ? $this->getAgenciaDv() : CalculoDV::bradescoAgencia($this->getAgencia()));

--- a/src/Cnab/Remessa/Cnab240/Banco/Btg.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Btg.php
@@ -190,8 +190,8 @@ class Btg extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_CUSTOM) {
             $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 73, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(74, 113, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(114, 128, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 15));
@@ -207,8 +207,8 @@ class Btg extends AbstractRemessa implements RemessaContract
         $this->add(233, 240, '');
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 209, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 40));
         }
 
@@ -294,8 +294,8 @@ class Btg extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(33, 52, Util::formatCnab('X', $this->getCodigoCliente(), 20));
         $this->add(53, 57, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(58, 58, Util::formatCnab('9', $this->getAgenciaDv(), 1));
@@ -337,8 +337,8 @@ class Btg extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '');
         $this->add(14, 16, '060');
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(34, 53, Util::formatCnab('X', '', 20));
         $this->add(54, 58, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(59, 59, Util::formatCnab('9', $this->getAgenciaDv(), 1));

--- a/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Caixa.php
@@ -207,8 +207,8 @@ class Caixa extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_CUSTOM) {
             $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 73, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(74, 113, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(114, 128, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 15));
@@ -224,8 +224,8 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(233, 240, '');
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 209, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 30));
         }
 
@@ -285,8 +285,8 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(33, 52, Util::formatCnab('9', 0, 20));
         $this->add(53, 57, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(58, 58, !is_null($this->getAgenciaDv()) ? $this->getAgenciaDv() : CalculoDV::cefAgencia($this->getAgencia()));
@@ -333,8 +333,8 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '00');
         $this->add(14, 16, strlen($this->getCodigoCliente()) == 7 ? '067' : '060');
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         if (strlen($this->getCodigoCliente()) == 7) {
             $this->add(34, 40, Util::formatCnab('9', Util::onlyNumbers($this->getCodigoCliente()), 7));
             $this->add(41, 53, Util::formatCnab('9', 0, 13));

--- a/src/Cnab/Remessa/Cnab240/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Itau.php
@@ -165,8 +165,8 @@ class Itau extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_CUSTOM) {
             $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 63, Util::formatCnab('X', $boleto->getPagador()->getNome(), 30));
         $this->add(64, 73, '');
         $this->add(74, 113, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
@@ -183,8 +183,8 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(213, 240, '');
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 199, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 30));
         }
 
@@ -214,8 +214,8 @@ class Itau extends AbstractRemessa implements RemessaContract
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
         $this->add(18, 19, '01');
-        $this->add(20, 20, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(21, 35, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+        $this->add(20, 20, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+        $this->add(21, 35, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
         $this->add(36, 75, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 40));
         $this->add(76, 115, Util::formatCnab('X', $boleto->getSacadorAvalista()->getEndereco(), 40));
         $this->add(116, 130, Util::formatCnab('X', $boleto->getSacadorAvalista()->getBairro(), 15));
@@ -242,8 +242,8 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(33, 52, '');
         $this->add(53, 53, 0);
         $this->add(54, 57, Util::formatCnab('9', $this->getAgencia(), 4));
@@ -287,8 +287,8 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '00');
         $this->add(14, 16, '030');
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(34, 53, '');
         $this->add(54, 54, '0');
         $this->add(55, 58, Util::formatCnab('9', $this->getAgencia(), 4));

--- a/src/Cnab/Remessa/Cnab240/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Santander.php
@@ -192,8 +192,8 @@ class Santander extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_ALTERACAO) {
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 73, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(74, 113, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(114, 128, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 15));
@@ -211,8 +211,8 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(222, 240, '');
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 209, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 30));
         }
 
@@ -268,8 +268,8 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 16, '');
-        $this->add(17, 17, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '2' : '1');
-        $this->add(18, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(17, 17, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '2' : '1');
+        $this->add(18, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(33, 47, Util::formatCnab('9', $this->getCodigoTransmissao(), 15));
         $this->add(48, 72, '');
         $this->add(73, 102, Util::formatCnab('X', $this->getBeneficiario()->getNome(), 30));
@@ -318,8 +318,8 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '');
         $this->add(14, 16, Util::formatCnab('9', '030', 3));
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '2' : '1');
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '2' : '1');
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(34, 53, '');
         $this->add(54, 68, Util::formatCnab('9', $this->getCodigoTransmissao(), 15));
         $this->add(69, 73, '');

--- a/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab240/Banco/Sicredi.php
@@ -248,8 +248,8 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         if ($boleto->getStatus() == $boleto::STATUS_CUSTOM) {
             $this->add(16, 17, sprintf('%2.02s', $boleto->getComando()));
         }
-        $this->add(18, 18, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($boleto->getPagador()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 15));
         $this->add(34, 73, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(74, 113, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(114, 128, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 15));
@@ -265,8 +265,8 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(233, 240, '');
 
         if ($boleto->getSacadorAvalista()) {
-            $this->add(154, 154, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-            $this->add(155, 169, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+            $this->add(154, 154, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+            $this->add(155, 169, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
             $this->add(170, 209, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 30));
         }
 
@@ -296,8 +296,8 @@ class Sicredi extends AbstractRemessa implements RemessaContract
             $this->add(16, 17, self::OCORRENCIA_ALT_OUTROS_DADOS);
         }
         $this->add(18, 19, '01');
-        $this->add(20, 20, strlen(Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(21, 35, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 15));
+        $this->add(20, 20, Util::isCnpj($boleto->getSacadorAvalista()->getDocumento()) ? 2 : 1);
+        $this->add(21, 35, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 15));
         $this->add(36, 75, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 40));
         $this->add(76, 115, Util::formatCnab('X', $boleto->getSacadorAvalista()->getEndereco(), 40));
         $this->add(116, 130, Util::formatCnab('X', $boleto->getSacadorAvalista()->getBairro(), 15));
@@ -324,8 +324,8 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(4, 7, '0000');
         $this->add(8, 8, '0');
         $this->add(9, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 32, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 32, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(33, 52, Util::formatCnab('X', '', 20));
         $this->add(53, 57, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(58, 58, '');
@@ -367,8 +367,8 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(12, 13, '');
         $this->add(14, 16, '040');
         $this->add(17, 17, '');
-        $this->add(18, 18, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? 2 : 1);
-        $this->add(19, 33, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 15));
+        $this->add(18, 18, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? 2 : 1);
+        $this->add(19, 33, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 15));
         $this->add(34, 53, Util::formatCnab('X', '', 20));
         $this->add(54, 58, Util::formatCnab('9', $this->getAgencia(), 5));
         $this->add(59, 59, '');

--- a/src/Cnab/Remessa/Cnab400/Banco/Abc.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Abc.php
@@ -143,8 +143,8 @@ class Abc extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe();
 
         $this->add(1, 1, '1');
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 37, Util::formatCnab('X', $this->getCodigoCliente(), 20));
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle
         $this->add(63, 73, Util::formatCnab('9', $boleto->getNossoNumero(), 11));
@@ -184,8 +184,8 @@ class Abc extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 264, Util::formatCnab('X', $boleto->getPagador()->getNome(), 30));
         $this->add(265, 274, Util::formatCnab('X', '', 10));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Bancoob.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bancoob.php
@@ -164,8 +164,8 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe(($chaveNfe = $boleto->getChaveNfe()) ? 44 : 0);
 
         $this->add(1, 1, 1);
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9L', $this->getBeneficiario()->getDocumento(), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 21, Util::formatCnab('9', $this->getAgencia(), 4));
         $this->add(22, 22, ! is_null($this->getAgenciaDv()) ? $this->getAgenciaDv() : CalculoDV::bancoobAgencia($this->getAgencia()));
         $this->add(23, 30, Util::formatCnab('9', $this->getConta(), 8));
@@ -228,8 +228,8 @@ class Bancoob extends AbstractRemessa implements RemessaContract
         $this->add(193, 193, '9');
         $this->add(194, 205, Util::formatCnab('9', 0, 12, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 271, Util::formatCnab('X', $boleto->getPagador()->getNome(), 37));
         $this->add(272, 274, '');
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Banrisul.php
@@ -298,8 +298,8 @@ class Banrisul extends AbstractRemessa implements RemessaContract
 
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 269, Util::formatCnab('X', $boleto->getPagador()->getNome(), 35));
         $this->add(270, 274, '');
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Bb.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bb.php
@@ -262,8 +262,8 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe(($chaveNfe = $boleto->getChaveNfe()) ? 44 : 0);
 
         $this->add(1, 1, 7);
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9L', $this->getBeneficiario()->getDocumento(), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 21, Util::formatCnab('9', $this->getAgencia(), 4));
         $this->add(22, 22, ! is_null($this->getAgenciaDv()) ? $this->getAgenciaDv() : CalculoDV::bbAgencia($this->getAgencia()));
         $this->add(23, 30, Util::formatCnab('9', $this->getConta(), 8));
@@ -320,8 +320,8 @@ class Bb extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 271, Util::formatCnab('X', $boleto->getPagador()->getNome(), 37));
         $this->add(272, 274, '');
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Bnb.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bnb.php
@@ -160,8 +160,8 @@ class Bnb extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 12));

--- a/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bradesco.php
@@ -219,8 +219,8 @@ class Bradesco extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 12));

--- a/src/Cnab/Remessa/Cnab400/Banco/Bv.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Bv.php
@@ -139,13 +139,13 @@ class Bv extends AbstractRemessa implements RemessaContract
 
         $this->add(1, 1, 1);
         if ($this->getBeneficiario()->getTipo() == Pessoa::TIPO_BENEFICIARIO) {
-            $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
+            $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
         } elseif ($this->getBeneficiario()->getTipo() == Pessoa::TIPO_SACADOR) {
-            $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '04' : '03');
+            $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '04' : '03');
         } else {
             throw new ValidationException('Tipo de beneficiário inválido');
         }
-        $this->add(4, 17, Util::formatCnab('9L', $this->getBeneficiario()->getDocumento(), 14));
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 19, '00');
         $this->add(20, 29, Util::formatCnab('9', $this->getConvenio(), 10));
         $this->add(30, 37, ''); // Número do Contrato Externo
@@ -191,8 +191,8 @@ class Bv extends AbstractRemessa implements RemessaContract
         $this->add(170, 170, '0'); // Desconto -  0 Percentual, 1 Valor
         $this->add(171, 182, Util::formatCnab('9', 0, 12, 2));
         $this->add(183, 195, Util::formatCnab('9', 0, 13, 2));
-        $this->add(196, 197, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(198, 211, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
+        $this->add(196, 197, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(198, 211, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(212, 251, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(252, 288, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 37));
         $this->add(289, 291, '');

--- a/src/Cnab/Remessa/Cnab400/Banco/C6.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/C6.php
@@ -147,8 +147,8 @@ class C6 extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe();
 
         $this->add(1, 1, '1');
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9L', $this->getBeneficiario()->getDocumento(), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 29, Util::formatCnab('9', $this->getCodigoCliente(), 12));
         $this->add(30, 37, '');
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle
@@ -185,8 +185,8 @@ class C6 extends AbstractRemessa implements RemessaContract
         $this->add(193, 198, $boleto->getMulta() > 0 ? $boleto->getDataVencimento()->format('dmy') : '000000');
         $this->add(199, 205, '');
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 12));

--- a/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Caixa.php
@@ -156,8 +156,8 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe(($chaveNfe = $boleto->getChaveNfe()) ? 44 : 0);
 
         $this->add(1, 1, '1');
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         if ($this->isLayout007()) {
             $this->add(18, 20, '000');
             $this->add(21, 27, Util::formatCnab('9', $this->getCodigoCliente(), 7));
@@ -206,8 +206,8 @@ class Caixa extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 12));

--- a/src/Cnab/Remessa/Cnab400/Banco/Cresol.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Cresol.php
@@ -215,8 +215,8 @@ class Cresol extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, '');

--- a/src/Cnab/Remessa/Cnab400/Banco/Daycoval.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Daycoval.php
@@ -149,13 +149,13 @@ class Daycoval extends AbstractRemessa implements RemessaContract
 
         $this->add(1, 1, '1');
         if ($this->getBeneficiario()->getTipo() == Pessoa::TIPO_BENEFICIARIO) {
-            $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
+            $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
         } elseif ($this->getBeneficiario()->getTipo() == Pessoa::TIPO_SACADOR) {
-            $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '04' : '03');
+            $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '04' : '03');
         } else {
             throw new ValidationException('Tipo de beneficiário inválido');
         }
-        $this->add(4, 17, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 37, Util::formatCnab('X', $this->getCodigoCliente(), 20));
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle
         $this->add(63, 70, Util::formatCnab('9', substr(substr($boleto->getNossoNumero(), -9), 0, -1), 8));
@@ -191,8 +191,8 @@ class Daycoval extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 264, Util::formatCnab('X', $boleto->getPagador()->getNome(), 30));
         $this->add(265, 274, Util::formatCnab('X', '', 10));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Delbank.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Delbank.php
@@ -128,7 +128,7 @@ class Delbank extends AbstractRemessa implements RemessaContract
 
         $this->add(1, 1, '1');
         $this->add(2, 3, '04');
-        $this->add(4, 17, Util::onlyNumbers($this->getBeneficiario()->getDocumento()));
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 37, Util::formatCnab('X', $this->getCodigoCliente(), 20));
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle
         $this->add(63, 73, Util::formatCnab('9', $boleto->getNossoNumero(), 11));
@@ -184,8 +184,8 @@ class Delbank extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 264, Util::formatCnab('X', $boleto->getPagador()->getNome(), 30));
         $this->add(265, 274, '');
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Fibra.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Fibra.php
@@ -134,8 +134,8 @@ class Fibra extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe();
 
         $this->add(1, 1, '1');
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 37, Util::formatCnab('X', $this->getAgencia() . Util::numberFormatGeral($this->getConta(), 8), 20));
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle
         $this->add(63, 73, Util::formatCnab('9', $boleto->getNossoNumero(), 11));
@@ -180,8 +180,8 @@ class Fibra extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 264, Util::formatCnab('X', $boleto->getPagador()->getNome(), 30));
         $this->add(265, 274, Util::formatCnab('X', '', 10));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Grafeno.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Grafeno.php
@@ -187,8 +187,8 @@ class Grafeno extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, Util::formatCnab('X', '', 12));

--- a/src/Cnab/Remessa/Cnab400/Banco/Hsbc.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Hsbc.php
@@ -151,8 +151,8 @@ class Hsbc extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe(($chaveNfe = $boleto->getChaveNfe()) ? 44 : 0);
 
         $this->add(1, 1, '1');
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9L', $this->getBeneficiario()->getDocumento(), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 18, 0);
         $this->add(19, 22, Util::formatCnab('9', $this->getAgencia(), 4));
         $this->add(23, 24, '55');
@@ -205,8 +205,8 @@ class Hsbc extends AbstractRemessa implements RemessaContract
         $this->add(174, 179, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmy') : '000000');
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 312, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 38));
         $this->add(313, 314, '00');

--- a/src/Cnab/Remessa/Cnab400/Banco/Inter.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Inter.php
@@ -116,8 +116,8 @@ class Inter extends AbstractRemessa implements RemessaContract
         $this->add(198, 201, '0000');
         $this->add(202, 207, $boleto->getDesconto() > 0 ? $boleto->getDataDesconto()->format('dmy') : '000000');
         $this->add(208, 220, Util::formatCnab('9', 0, 13, 2));
-        $this->add(221, 222, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(223, 236, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(221, 222, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(223, 236, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(237, 276, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(277, 316, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(317, 324, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getCep()), 8));

--- a/src/Cnab/Remessa/Cnab400/Banco/Itau.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Itau.php
@@ -178,8 +178,8 @@ class Itau extends AbstractRemessa implements RemessaContract
         $pix = $boleto->validarPix();
 
         $this->add(1, 1, '1');
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 21, Util::formatCnab('9', $this->getAgencia(), 4));
         $this->add(22, 23, '00');
         $this->add(24, 28, Util::formatCnab('9', $this->getConta(), 5));
@@ -225,8 +225,8 @@ class Itau extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 264, Util::formatCnab('X', $boleto->getPagador()->getNome(), 30));
         $this->add(265, 274, '');
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Ourinvest.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Ourinvest.php
@@ -147,8 +147,8 @@ class Ourinvest extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 312, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 38));
         $this->add(313, 324, Util::formatCnab('X', $boleto->getPagador()->getCidade(), 12));
@@ -156,7 +156,7 @@ class Ourinvest extends AbstractRemessa implements RemessaContract
         $this->add(327, 334, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getCep()), 8));
         $this->add(335, 394, Util::formatCnab('X', '', 60));
         if ($boleto->getSacadorAvalista()) {
-            $this->add(335, 348, Util::formatCnab('9', Util::onlyNumbers($boleto->getSacadorAvalista()->getDocumento()), 14));
+            $this->add(335, 348, Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 14));
             $this->add(349, 350, Util::formatCnab('X', '', 2));
             $this->add(351, 394, Util::formatCnab('X', $boleto->getSacadorAvalista()->getNome(), 44));
         }

--- a/src/Cnab/Remessa/Cnab400/Banco/Pine.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Pine.php
@@ -132,8 +132,8 @@ class Pine extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe();
 
         $this->add(1, 1, '1');
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 37, Util::formatCnab('X', Util::numberFormatGeral((int) $this->getCodigoCliente(), 9), 20));
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle
         $this->add(63, 73, Util::formatCnab('9', $boleto->getNossoNumero(), 11));
@@ -173,8 +173,8 @@ class Pine extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 264, Util::formatCnab('X', $boleto->getPagador()->getNome(), 30));
         $this->add(265, 274, Util::formatCnab('X', '', 10));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Rendimento.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Rendimento.php
@@ -141,8 +141,8 @@ class Rendimento extends AbstractRemessa implements RemessaContract
         $this->iniciaDetalhe();
 
         $this->add(1, 1, '1');
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9', Util::onlyNumbers($this->getBeneficiario()->getDocumento()), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 37, Util::formatCnab('X', $this->getCodigoCliente(), 20));
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle
         $this->add(63, 73, Util::formatCnab('9', $boleto->getNossoNumero(), 11));
@@ -182,8 +182,8 @@ class Rendimento extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 264, Util::formatCnab('X', $boleto->getPagador()->getNome(), 30));
         $this->add(265, 274, Util::formatCnab('X', '', 10));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));

--- a/src/Cnab/Remessa/Cnab400/Banco/Santander.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Santander.php
@@ -164,8 +164,8 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->total += $boleto->getValor();
 
         $this->add(1, 1, '1');
-        $this->add(2, 3, strlen(Util::onlyNumbers($this->getBeneficiario()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(4, 17, Util::formatCnab('9L', $this->getBeneficiario()->getDocumento(), 14));
+        $this->add(2, 3, Util::isCnpj($this->getBeneficiario()->getDocumento()) ? '02' : '01');
+        $this->add(4, 17, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(18, 37, Util::formatCnab('9', $this->getCodigoTransmissao(), 20));
         $this->add(38, 62, Util::formatCnab('X', $boleto->getNumeroControle(), 25)); // numero de controle
         $this->add(63, 70, substr(Util::onlyNumbers($boleto->getNossoNumero()), -8));
@@ -213,8 +213,8 @@ class Santander extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 12));

--- a/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Sicredi.php
@@ -127,7 +127,7 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(10, 11, '01');
         $this->add(12, 26, Util::formatCnab('X', 'COBRANCA', 15));
         $this->add(27, 31, Util::formatCnab('9', $this->getCodigoCliente(), 5));
-        $this->add(32, 45, Util::formatCnab('9L', $this->getBeneficiario()->getDocumento(), 14, 0, 0));
+        $this->add(32, 45, Util::formatCnabDocumento($this->getBeneficiario()->getDocumento(), 14));
         $this->add(46, 76, '');
         $this->add(77, 79, $this->getCodigoBanco());
         $this->add(80, 94, Util::formatCnab('X', 'Sicredi', 15));
@@ -209,8 +209,8 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '20' : '10');
-        $this->add(221, 234, Util::formatCnab('9L', $boleto->getPagador()->getDocumento(), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '20' : '10');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 319, '00000');
@@ -218,7 +218,7 @@ class Sicredi extends AbstractRemessa implements RemessaContract
         $this->add(326, 326, ' ');
         $this->add(327, 334, Util::formatCnab('9L', $boleto->getPagador()->getCep(), 8));
         $this->add(335, 339, '00000');
-        $this->add(340, 353, $boleto->getSacadorAvalista() ? Util::formatCnab('9L', $boleto->getSacadorAvalista()->getDocumento(), 14) : Util::formatCnab('X', '', 14));
+        $this->add(340, 353, $boleto->getSacadorAvalista() ? Util::formatCnabDocumento($boleto->getSacadorAvalista()->getDocumento(), 14) : Util::formatCnab('X', '', 14));
         $this->add(354, 394, Util::formatCnab('X', $boleto->getSacadorAvalista() ? $boleto->getSacadorAvalista()->getNome() : '', 41));
         $this->add(395, 400, Util::formatCnab('9', $this->iRegistros + 1, 6));
         if ($chaveNfe) {

--- a/src/Cnab/Remessa/Cnab400/Banco/Sisprime.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Sisprime.php
@@ -195,8 +195,8 @@ class Sisprime extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, '0000000000000');
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, '000000000000');

--- a/src/Cnab/Remessa/Cnab400/Banco/Unicred.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Unicred.php
@@ -236,7 +236,7 @@ class Unicred extends AbstractRemessa implements RemessaContract
         // Tipo de inscrição do Pagador
         // 01 – CPF
         // 02 - CNPJ
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01'); //Identificação do Tipo de Inscrição do Pagador
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01'); //Identificação do Tipo de Inscrição do Pagador
         /** Quando se tratar de CNPJ, adotar o critério de preenchimento da direita para a esquerda,utilizando:
          * - 2 posições para o controle;
          * - 4 posições para a filial;
@@ -246,7 +246,7 @@ class Unicred extends AbstractRemessa implements RemessaContract
          * - 9 posições para o CPF;
          * - 3 posições a esquerda zeradas.
          **/
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, Util::formatCnab('X', $boleto->getPagador()->getBairro(), 12));

--- a/src/Cnab/Remessa/Cnab400/Banco/Vortx.php
+++ b/src/Cnab/Remessa/Cnab400/Banco/Vortx.php
@@ -187,8 +187,8 @@ class Vortx extends AbstractRemessa implements RemessaContract
         $this->add(180, 192, Util::formatCnab('9', $boleto->getDesconto(), 13, 2));
         $this->add(193, 205, Util::formatCnab('9', 0, 13, 2));
         $this->add(206, 218, Util::formatCnab('9', 0, 13, 2));
-        $this->add(219, 220, strlen(Util::onlyNumbers($boleto->getPagador()->getDocumento())) == 14 ? '02' : '01');
-        $this->add(221, 234, Util::formatCnab('9', Util::onlyNumbers($boleto->getPagador()->getDocumento()), 14));
+        $this->add(219, 220, Util::isCnpj($boleto->getPagador()->getDocumento()) ? '02' : '01');
+        $this->add(221, 234, Util::formatCnabDocumento($boleto->getPagador()->getDocumento(), 14));
         $this->add(235, 274, Util::formatCnab('X', $boleto->getPagador()->getNome(), 40));
         $this->add(275, 314, Util::formatCnab('X', $boleto->getPagador()->getEndereco(), 40));
         $this->add(315, 326, Util::formatCnab('X', '', 12));

--- a/src/Pessoa.php
+++ b/src/Pessoa.php
@@ -194,8 +194,15 @@ class Pessoa implements PessoaContract
      */
     public function setDocumento($documento)
     {
-        $documento = substr(Util::onlyNumbers($documento), -14);
-        if (! in_array(strlen($documento), [10, 11, 14, 0])) {
+        $documento = substr(Util::onlyDocument($documento), -14);
+        $length = strlen($documento);
+        if (! in_array($length, [10, 11, 14, 0])) {
+            throw new ValidationException('Documento inválido');
+        }
+        if (in_array($length, [10, 11]) && ! ctype_digit($documento)) {
+            throw new ValidationException('Documento inválido');
+        }
+        if ($length == 14 && ! preg_match('/^[A-Z0-9]{12}[0-9]{2}$/', $documento)) {
             throw new ValidationException('Documento inválido');
         }
         $this->documento = $documento;
@@ -216,7 +223,7 @@ class Pessoa implements PessoaContract
             return Util::maskString(Util::onlyNumbers($this->documento), '##.#####.#-##');
         }
 
-        return Util::maskString(Util::onlyNumbers($this->documento), '##.###.###/####-##');
+        return Util::maskString(Util::onlyDocument($this->documento), '##.###.###/####-##');
     }
 
     /**
@@ -360,15 +367,7 @@ class Pessoa implements PessoaContract
      */
     public function getTipoDocumento()
     {
-        $cpf_cnpj_cei = Util::onlyNumbers($this->documento);
-
-        if (strlen($cpf_cnpj_cei) == 11) {
-            return 'CPF';
-        } elseif (strlen($cpf_cnpj_cei) == 10) {
-            return 'CEI';
-        }
-
-        return 'CNPJ';
+        return Util::getTipoDocumento($this->documento) ?: 'CNPJ';
     }
 
     /**

--- a/src/Util.php
+++ b/src/Util.php
@@ -314,6 +314,55 @@ final class Util
     }
 
     /**
+     * Retorna somente caracteres validos para documentos CPF/CNPJ/CEI.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    public static function onlyDocument($string)
+    {
+        return preg_replace('/[^0-9A-Z]/', '', self::upper(self::normalizeChars((string) $string)));
+    }
+
+    /**
+     * @param string $documento
+     * @return string|null
+     */
+    public static function getTipoDocumento($documento)
+    {
+        $documento = self::onlyDocument($documento);
+        if (strlen($documento) == 11 && ctype_digit($documento)) {
+            return 'CPF';
+        } elseif (strlen($documento) == 10 && ctype_digit($documento)) {
+            return 'CEI';
+        } elseif (strlen($documento) == 14 && preg_match('/^[A-Z0-9]{12}[0-9]{2}$/', $documento)) {
+            return 'CNPJ';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string $documento
+     * @return bool
+     */
+    public static function isCnpj($documento)
+    {
+        return self::getTipoDocumento($documento) == 'CNPJ';
+    }
+
+    /**
+     * @param string $documento
+     * @param int $tamanho
+     * @return string
+     */
+    public static function formatCnabDocumento($documento, $tamanho = 14)
+    {
+        return self::formatCnab('9', self::onlyDocument($documento), $tamanho);
+    }
+
+    /**
      * Função para limpar acentos de uma string
      *
      * @param string $string
@@ -1218,16 +1267,16 @@ final class Util
      */
     public static function validarCnpj($cnpj)
     {
-        $c = self::onlyNumbers($cnpj);
+        $c = self::onlyDocument($cnpj);
         $b = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
-        if (mb_strlen($c) != 14 || preg_match("/^{$c[0]}{14}$/", $c)) {
+        if (mb_strlen($c) != 14 || ! preg_match('/^[A-Z0-9]{12}[0-9]{2}$/', $c) || preg_match("/^{$c[0]}{14}$/", $c)) {
             return false;
         }
-        for ($i = 0, $n = 0; $i < 12; $n += $c[$i] * $b[++$i]);
+        for ($i = 0, $n = 0; $i < 12; $n += self::cnpjCharValue($c[$i]) * $b[++$i]);
         if ($c[12] != ((($n %= 11) < 2) ? 0 : 11 - $n)) {
             return false;
         }
-        for ($i = 0, $n = 0; $i <= 12; $n += $c[$i] * $b[$i++]);
+        for ($i = 0, $n = 0; $i <= 12; $n += self::cnpjCharValue($c[$i]) * $b[$i++]);
         if ($c[13] != ((($n %= 11) < 2) ? 0 : 11 - $n)) {
             return false;
         }
@@ -1236,13 +1285,22 @@ final class Util
     }
 
     /**
+     * @param string $char
+     * @return int
+     */
+    private static function cnpjCharValue($char)
+    {
+        return ord($char) - 48;
+    }
+
+    /**
      * @param $documento
      * @return bool
      */
     public static function validarCnpjCpf($documento)
     {
-        $documento = Util::onlyNumbers($documento);
-        if (strlen($documento) == 11) {
+        $documento = Util::onlyDocument($documento);
+        if (strlen($documento) == 11 && ctype_digit($documento)) {
             return self::validarCpf($documento);
         } elseif (strlen($documento) == 14) {
             return self::validarCnpj($documento);

--- a/tests/PessoaTest.php
+++ b/tests/PessoaTest.php
@@ -132,6 +132,14 @@ class PessoaTest extends TestCase
         $this->assertEquals('CNPJ', $pessoa->getTipoDocumento());
         $this->assertEquals('99.999.999/9999-99', $pessoa->getDocumento());
 
+        $pessoa->setDocumento('12.ABC.345/01DE-35');
+        $this->assertEquals('CNPJ', $pessoa->getTipoDocumento());
+        $this->assertEquals('12.ABC.345/01DE-35', $pessoa->getDocumento());
+
+        $pessoa->setDocumento('12abc34501de35');
+        $this->assertEquals('CNPJ', $pessoa->getTipoDocumento());
+        $this->assertEquals('12.ABC.345/01DE-35', $pessoa->getDocumento());
+
         $pessoa->setDocumento('999.999.999-99');
         $this->assertEquals('CPF', $pessoa->getTipoDocumento());
         $this->assertEquals('999.999.999-99', $pessoa->getDocumento());
@@ -146,5 +154,13 @@ class PessoaTest extends TestCase
         $this->assertEquals('CEI', $pessoa->getTipoDocumento());
         $this->assertEquals('99.99999.9-99', $pessoa->getDocumento());
 
+    }
+
+    public function testPessoaDocumentoCpfAlfanumericoErrado()
+    {
+        $this->expectException(Exception::class);
+
+        $pessoa = new Pessoa;
+        $pessoa->setDocumento('ABCDE123456');
     }
 }

--- a/tests/Remessa/RemessaCnab240Test.php
+++ b/tests/Remessa/RemessaCnab240Test.php
@@ -95,6 +95,62 @@ class RemessaCnab240Test extends TestCase
         $this->assertEquals($file, $file2);
     }
 
+    public function testRemessaSantanderCnab240ComCnpjAlfanumerico()
+    {
+        $beneficiario = new Pessoa([
+            'nome' => 'ACME',
+            'endereco' => 'Rua um, 123',
+            'cep' => '99999-999',
+            'uf' => 'UF',
+            'cidade' => 'CIDADE',
+            'documento' => '12.ABC.345/01DE-35',
+        ]);
+
+        $pagador = new Pessoa([
+            'nome' => 'Cliente',
+            'endereco' => 'Rua um, 123',
+            'bairro' => 'Bairro',
+            'cep' => '99999-999',
+            'uf' => 'UF',
+            'cidade' => 'CIDADE',
+            'documento' => '12ABC34501DE35',
+        ]);
+
+        $boleto = new Boleto\Santander([
+            'logo' => realpath(__DIR__ . '/../logos/') . DIRECTORY_SEPARATOR . '033.png',
+            'dataVencimento' => $this->vencimento(),
+            'valor' => $this->valor(),
+            'multa' => $this->multa(),
+            'juros' => $this->juros(),
+            'numero' => 1,
+            'numeroDocumento' => 1,
+            'pagador' => $pagador,
+            'beneficiario' => $beneficiario,
+            'diasBaixaAutomatica' => 15,
+            'carteira' => 101,
+            'agencia' => 1111,
+            'conta' => 99999999,
+            'descricaoDemonstrativo' => ['demonstrativo 1', 'demonstrativo 2', 'demonstrativo 3'],
+            'instrucoes' => ['instrucao 1', 'instrucao 2', 'instrucao 3'],
+            'aceite' => 'S',
+            'especieDoc' => 'DM',
+        ]);
+
+        $remessa = new Remessa\Santander([
+            'idremessa' => 1,
+            'agencia' => 1111,
+            'carteira' => 101,
+            'conta' => 99999999,
+            'codigoCliente' => 12345678,
+            'beneficiario' => $beneficiario,
+        ]);
+        $remessa->addBoleto($boleto);
+
+        $cnab = $remessa->gerar();
+
+        $this->assertStringContainsString('012ABC34501DE35', $cnab);
+    }
+
     public function testRemessaItauCnab240()
     {
         $boleto = new Boleto\Itau([

--- a/tests/Remessa/RemessaCnab400Test.php
+++ b/tests/Remessa/RemessaCnab400Test.php
@@ -583,6 +583,61 @@ class RemessaCnab400Test extends TestCase
         $this->assertEquals($file, $file2);
     }
 
+    public function testRemessaSantanderCnab400ComCnpjAlfanumerico()
+    {
+        $beneficiario = new Pessoa([
+            'nome'      => 'ACME',
+            'endereco'  => 'Rua um, 123',
+            'cep'       => '99999-999',
+            'uf'        => 'UF',
+            'cidade'    => 'CIDADE',
+            'documento' => '12.ABC.345/01DE-35',
+        ]);
+
+        $pagador = new Pessoa([
+            'nome'      => 'Cliente',
+            'endereco'  => 'Rua um, 123',
+            'bairro'    => 'Bairro',
+            'cep'       => '99999-999',
+            'uf'        => 'UF',
+            'cidade'    => 'CIDADE',
+            'documento' => '12ABC34501DE35',
+        ]);
+
+        $boleto = new Boleto\Santander([
+            'logo'                   => realpath(__DIR__ . '/../logos/') . DIRECTORY_SEPARATOR . '033.png',
+            'dataVencimento'         => $this->vencimento(),
+            'valor'                  => $this->valor(),
+            'multa'                  => $this->multa(),
+            'juros'                  => $this->juros(),
+            'numero'                 => 1,
+            'numeroDocumento'        => 1,
+            'pagador'                => $pagador,
+            'beneficiario'           => $beneficiario,
+            'diasBaixaAutomatica'    => 15,
+            'carteira'               => 101,
+            'agencia'                => 1111,
+            'conta'                  => 99999999,
+            'descricaoDemonstrativo' => ['demonstrativo 1', 'demonstrativo 2', 'demonstrativo 3'],
+            'instrucoes'             => ['instrucao 1', 'instrucao 2', 'instrucao 3'],
+            'aceite'                 => 'S',
+            'especieDoc'             => 'DM',
+        ]);
+
+        $remessa = new Remessa\Santander([
+            'agencia'       => 1111,
+            'carteira'      => 101,
+            'conta'         => 99999999,
+            'codigoCliente' => 12345678,
+            'beneficiario'  => $beneficiario,
+        ]);
+        $remessa->addBoleto($boleto);
+
+        $cnab = $remessa->gerar();
+
+        $this->assertStringContainsString('12ABC34501DE35', $cnab);
+    }
+
     public function testRemessaSicrediCnab400()
     {
         $boleto = new Boleto\Sicredi([

--- a/tests/UtilTest.php
+++ b/tests/UtilTest.php
@@ -32,6 +32,8 @@ class UtilTest extends TestCase
         $this->assertEquals('123', Util::onlyNumbers('asd123'));
         $this->assertEquals('asd123', Util::alphanumberOnly('_*(asd123)*_'));
         $this->assertEquals('asd123', Util::onlyAlphanumber('_*(asd123)*_'));
+        $this->assertEquals('12ABC34501DE35', Util::onlyDocument('12.abc.345/01de-35'));
+        $this->assertEquals('012ABC34501DE35', Util::formatCnabDocumento('12.abc.345/01de-35', 15));
         $this->assertEquals('AaEeIiOoUu', Util::normalizeChars('ÁáÉéÍiÓóÚú'));
     }
 
@@ -40,6 +42,18 @@ class UtilTest extends TestCase
         $this->assertEquals(7, Util::modulo11('123456789', 2, 9));
         $this->assertEquals(4, Util::modulo11('123456789', 2, 9, 1));
         $this->assertEquals(7, Util::modulo10('123456789'));
+    }
+
+    public function testValidarCnpjAlfanumerico()
+    {
+        $this->assertTrue(Util::validarCnpj('12.ABC.345/01DE-35'));
+        $this->assertTrue(Util::validarCnpj('12abc34501de35'));
+        $this->assertTrue(Util::validarCnpjCpf('12.ABC.345/01DE-35'));
+        $this->assertEquals('CNPJ', Util::getTipoDocumento('12.ABC.345/01DE-35'));
+        $this->assertTrue(Util::isCnpj('12.ABC.345/01DE-35'));
+        $this->assertFalse(Util::validarCnpj('12.ABC.345/01DE-34'));
+        $this->assertFalse(Util::validarCnpj('12.ABC.345/01DE-AA'));
+        $this->assertFalse(Util::validarCnpjCpf('ABCDE123456'));
     }
 
     public function testAddRem()


### PR DESCRIPTION
## Summary
- Add document normalization helpers that preserve alphanumeric CNPJ values
- Update CNPJ validation to follow the Receita Federal alphanumeric DV rule
- Preserve alphanumeric CNPJ values in CNAB/API document fields while keeping numeric CPF behavior
- Add regression coverage for Pessoa, Util, Santander CNAB 240 and CNAB 400

## Tests
- vendor/bin/phpunit
- php -l on changed PHP files
- git diff --check